### PR TITLE
Improve terminal color handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,7 @@ bbs_SOURCES = \
 	browser.c \
 	bbsrc.c \
 	color.c \
+	color_themes.c \
 	config.c \
 	edit.c \
 	filter.c \
@@ -44,7 +45,7 @@ test_inkey_LDADD = $(CMOCKA_LIBS)
 test_filter_SOURCES = test/test_filter.c test/test_helpers.c browser.c filter.c queue.c slist.c global.c
 test_filter_CFLAGS = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_filter_LDADD = $(CMOCKA_LIBS)
-test_color_SOURCES = test/test_color.c test/test_helpers.c color.c slist.c global.c
+test_color_SOURCES = test/test_color.c test/test_helpers.c color.c color_themes.c slist.c global.c
 test_color_CFLAGS = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_color_LDADD = $(CMOCKA_LIBS)
 test_config_SOURCES = test/test_config.c test/test_helpers.c config.c slist.c global.c

--- a/bbsrc.c
+++ b/bbsrc.c
@@ -89,9 +89,19 @@ static bool parseNamedColorScheme( const char *ptrColorSpec, int *ptrColorValues
       memcpy( aryToken, ptrTokenStart, tokenLength );
       aryToken[tokenLength] = '\0';
 
-      if ( tokenLength == 1 && aryToken[0] >= '0' && aryToken[0] <= '9' )
+      if ( isdigit( (unsigned char)aryToken[0] ) )
       {
-         colorValue = colorValueFromLegacyDigit( aryToken[0] );
+         size_t digitIndex;
+
+         colorValue = 0;
+         for ( digitIndex = 0; digitIndex < tokenLength; digitIndex++ )
+         {
+            if ( !isdigit( (unsigned char)aryToken[digitIndex] ) )
+            {
+               return false;
+            }
+            colorValue = colorValue * 10 + ( aryToken[digitIndex] - '0' );
+         }
       }
       else
       {

--- a/bbsrc.c
+++ b/bbsrc.c
@@ -128,6 +128,10 @@ static bool parseColorScheme( const char *ptrLine, int *ptrColorValues )
       {
          ptrColorValues[colorIndex] = colorValueFromLegacyDigit( ptrLine[6 + colorIndex] );
       }
+      if ( ptrLine[6 + COLOR_BACKGROUND_INDEX] == '9' )
+      {
+         ptrColorValues[COLOR_BACKGROUND_INDEX] = COLOR_VALUE_DEFAULT;
+      }
       return true;
    }
 

--- a/bbsrc.c
+++ b/bbsrc.c
@@ -43,12 +43,86 @@ static int ctrl( const char *ptrToken )
  * Parses the bbsrc file, setting necessary globals depending on the content of
  * the bbsrc, or returning an error if the bbsrc couldn't be properly parsed.
  */
-#define MAX_LINE_LENGTH 83
+#define MAX_LINE_LENGTH 255
 #define FRIEND_COMMAND_PREFIX_LEN 7
 #define FRIEND_NAME_PARSE_LENGTH 19
 #define FRIEND_INFO_OFFSET 30
 #define FRIEND_INFO_COPY_LENGTH 53
 #define FRIEND_RECORD_MAGIC 0x3231
+
+static bool parseNamedColorScheme( const char *ptrColorSpec, int *ptrColorValues )
+{
+   int colorIndex;
+
+   colorIndex = 0;
+   while ( *ptrColorSpec != '\0' )
+   {
+      char aryToken[16];
+      int colorValue;
+      size_t tokenLength;
+      const char *ptrTokenStart;
+
+      while ( isspace( (unsigned char)*ptrColorSpec ) )
+      {
+         ptrColorSpec++;
+      }
+      if ( *ptrColorSpec == '\0' )
+      {
+         break;
+      }
+      if ( colorIndex >= COLOR_FIELD_COUNT )
+      {
+         return false;
+      }
+
+      ptrTokenStart = ptrColorSpec;
+      while ( *ptrColorSpec != '\0' && !isspace( (unsigned char)*ptrColorSpec ) )
+      {
+         ptrColorSpec++;
+      }
+      tokenLength = (size_t)( ptrColorSpec - ptrTokenStart );
+      if ( tokenLength == 0 || tokenLength >= sizeof( aryToken ) )
+      {
+         return false;
+      }
+
+      memcpy( aryToken, ptrTokenStart, tokenLength );
+      aryToken[tokenLength] = '\0';
+
+      if ( tokenLength == 1 && aryToken[0] >= '0' && aryToken[0] <= '9' )
+      {
+         colorValue = colorValueFromLegacyDigit( aryToken[0] );
+      }
+      else
+      {
+         colorValue = colorValueFromName( aryToken );
+      }
+      if ( colorValue < 0 )
+      {
+         return false;
+      }
+
+      ptrColorValues[colorIndex++] = colorValue;
+   }
+
+   return colorIndex == COLOR_FIELD_COUNT;
+}
+
+static bool parseColorScheme( const char *ptrLine, int *ptrColorValues )
+{
+   if ( strlen( ptrLine ) == 6 + COLOR_FIELD_COUNT )
+   {
+      int colorIndex;
+
+      for ( colorIndex = 0; colorIndex < COLOR_FIELD_COUNT; colorIndex++ )
+      {
+         ptrColorValues[colorIndex] = colorValueFromLegacyDigit( ptrLine[6 + colorIndex] );
+      }
+      return true;
+   }
+
+   return parseNamedColorScheme( ptrLine + 6, ptrColorValues );
+}
 
 typedef enum
 {
@@ -330,19 +404,13 @@ void readBbsRc( void )
             }
 
          case BBRC_CMD_COLOR:
-            if ( strlen( aryLine ) != 6 + COLOR_FIELD_COUNT )
-            {
-               stdPrintf( "Invalid 'color' scheme on line %d, ignored.\n", lineNumber );
-            }
-            else
             {
                int *ptrColorValues;
-               int colorIndex;
 
                ptrColorValues = (int *)&color;
-               for ( colorIndex = 0; colorIndex < COLOR_FIELD_COUNT; colorIndex++ )
+               if ( !parseColorScheme( aryLine, ptrColorValues ) )
                {
-                  ptrColorValues[colorIndex] = colorValueFromLegacyDigit( aryLine[6 + colorIndex] );
+                  stdPrintf( "Invalid 'color' scheme on line %d, ignored.\n", lineNumber );
                }
             }
             break;

--- a/bbsrc.c
+++ b/bbsrc.c
@@ -330,13 +330,20 @@ void readBbsRc( void )
             }
 
          case BBRC_CMD_COLOR:
-            if ( strlen( aryLine ) != 6 + sizeof color )
+            if ( strlen( aryLine ) != 6 + COLOR_FIELD_COUNT )
             {
                stdPrintf( "Invalid 'color' scheme on line %d, ignored.\n", lineNumber );
             }
             else
             {
-               bcopy( aryLine + 6, (void *)&color, sizeof color );
+               int *ptrColorValues;
+               int colorIndex;
+
+               ptrColorValues = (int *)&color;
+               for ( colorIndex = 0; colorIndex < COLOR_FIELD_COUNT; colorIndex++ )
+               {
+                  ptrColorValues[colorIndex] = colorValueFromLegacyDigit( aryLine[6 + colorIndex] );
+               }
             }
             break;
 

--- a/browser.c
+++ b/browser.c
@@ -268,12 +268,16 @@ static void clearDetectedUrlQueue( void )
 
 static void applyVisibleUrlReportColor( int foregroundColor )
 {
+   char aryAnsiSequence[32];
+
    if ( !flagsConfiguration.useAnsi )
    {
       return;
    }
-   stdPrintf( "\033[%cm\033[3%d;4%dm", flagsConfiguration.useBold ? '1' : '0',
-              foregroundColor, color.background );
+   formatAnsiDisplayStateSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                   foregroundColor, color.background,
+                                   flagsConfiguration.useBold );
+   stdPrintf( "%s", aryAnsiSequence );
    lastColor = foregroundColor;
 }
 

--- a/browser.c
+++ b/browser.c
@@ -266,13 +266,13 @@ static void clearDetectedUrlQueue( void )
    }
 }
 
-static void applyVisibleUrlReportColor( char foregroundColor )
+static void applyVisibleUrlReportColor( int foregroundColor )
 {
    if ( !flagsConfiguration.useAnsi )
    {
       return;
    }
-   stdPrintf( "\033[%cm\033[3%c;4%cm", flagsConfiguration.useBold ? '1' : '0',
+   stdPrintf( "\033[%cm\033[3%d;4%dm", flagsConfiguration.useBold ? '1' : '0',
               foregroundColor, color.background );
    lastColor = foregroundColor;
 }

--- a/color.c
+++ b/color.c
@@ -24,6 +24,15 @@ typedef struct
 
 static const NamedColorSpec aryNamedColors[] =
    {
+      { "brightblack", 8 },
+      { "brightred", 9 },
+      { "brightgreen", 10 },
+      { "brightyellow", 11 },
+      { "brightblue", 12 },
+      { "brightmagenta", 13 },
+      { "brightpurple", 13 },
+      { "brightcyan", 14 },
+      { "brightwhite", 15 },
       { "black", 16 },
       { "red", 160 },
       { "green", 34 },
@@ -33,7 +42,7 @@ static const NamedColorSpec aryNamedColors[] =
       { "purple", 91 },
       { "cyan", 44 },
       { "white", 231 },
-      { "default", 9 } };
+      { "default", COLOR_VALUE_DEFAULT } };
 
 static bool isColorNameMatch( const char *ptrLeft, const char *ptrRight )
 {
@@ -908,7 +917,7 @@ int backgroundPicker( void )
          break;
       case 'd':
          stdPrintf( "Default\r\n" );
-         inputChar = 9;
+         inputChar = COLOR_VALUE_DEFAULT;
          break;
       default:
          inputChar = 0; /* If your text goes black it's a bug here */

--- a/color.c
+++ b/color.c
@@ -16,6 +16,40 @@ static const char *COLOR_USER_OR_FRIEND_KEYS = "ufq \n";
 static const char *COLOR_FOREGROUND_KEYS = "krgybmcw";
 static const char *COLOR_BACKGROUND_KEYS = "krgybmcwd";
 
+typedef struct
+{
+   const char *ptrName;
+   int colorValue;
+} NamedColorSpec;
+
+static const NamedColorSpec aryNamedColors[] =
+   {
+      { "black", 16 },
+      { "red", 160 },
+      { "green", 34 },
+      { "yellow", 220 },
+      { "blue", 26 },
+      { "magenta", 91 },
+      { "purple", 91 },
+      { "cyan", 44 },
+      { "white", 231 },
+      { "default", 9 } };
+
+static bool isColorNameMatch( const char *ptrLeft, const char *ptrRight )
+{
+   while ( *ptrLeft && *ptrRight )
+   {
+      if ( tolower( (unsigned char)*ptrLeft ) != tolower( (unsigned char)*ptrRight ) )
+      {
+         return false;
+      }
+      ptrLeft++;
+      ptrRight++;
+   }
+
+   return *ptrLeft == '\0' && *ptrRight == '\0';
+}
+
 /*
  * defaultColors is called once with an arg of 1 before the bbsrc file is
  * read.  This initializes all the color variables.  It is then called again
@@ -69,6 +103,41 @@ int colorValueFromLegacyDigit( int inputChar )
 int colorValueToLegacyDigit( int colorValue )
 {
    return colorValue + '0';
+}
+
+int colorValueFromName( const char *ptrColorName )
+{
+   size_t itemIndex;
+
+   if ( ptrColorName == NULL || *ptrColorName == '\0' )
+   {
+      return -1;
+   }
+
+   for ( itemIndex = 0; itemIndex < sizeof( aryNamedColors ) / sizeof( aryNamedColors[0] ); itemIndex++ )
+   {
+      if ( isColorNameMatch( ptrColorName, aryNamedColors[itemIndex].ptrName ) )
+      {
+         return aryNamedColors[itemIndex].colorValue;
+      }
+   }
+
+   return -1;
+}
+
+const char *colorNameFromValue( int colorValue )
+{
+   size_t itemIndex;
+
+   for ( itemIndex = 0; itemIndex < sizeof( aryNamedColors ) / sizeof( aryNamedColors[0] ); itemIndex++ )
+   {
+      if ( aryNamedColors[itemIndex].colorValue == colorValue )
+      {
+         return aryNamedColors[itemIndex].ptrName;
+      }
+   }
+
+   return NULL;
 }
 
 int ansiTransform( int inputChar )

--- a/color.c
+++ b/color.c
@@ -24,59 +24,77 @@ static const char *COLOR_BACKGROUND_KEYS = "krgybmcwd";
  * which might use those reserved fields - they will get their default values
  * instead of zero, which would render as black.
  */
-#define ifzero( x ) if ( ( x ) < '1' || ( x ) > '7' || clearall )
+#define ifzero( x ) if ( ( x ) < 1 || ( x ) > 7 || clearall )
 void defaultColors( int clearall )
 {
-   ifzero( color.text ) color.text = '2';
-   ifzero( color.forum ) color.forum = '3';
-   ifzero( color.number ) color.number = '6';
-   ifzero( color.errorTextColor ) color.errorTextColor = '1';
-   color.reserved1 = '0';
-   color.reserved2 = '0';
-   color.reserved3 = '0';
-   ifzero( color.postdate ) color.postdate = '5';
-   ifzero( color.postname ) color.postname = '6';
-   ifzero( color.posttext ) color.posttext = '2';
-   ifzero( color.postfrienddate ) color.postfrienddate = '5';
-   ifzero( color.postfriendname ) color.postfriendname = '1';
-   ifzero( color.postfriendtext ) color.postfriendtext = '2';
-   ifzero( color.anonymous ) color.anonymous = '3';
-   ifzero( color.moreprompt ) color.moreprompt = '3';
-   color.reserved4 = '0';
-   color.reserved5 = '0';
+   ifzero( color.text ) color.text = 2;
+   ifzero( color.forum ) color.forum = 3;
+   ifzero( color.number ) color.number = 6;
+   ifzero( color.errorTextColor ) color.errorTextColor = 1;
+   color.reserved1 = 0;
+   color.reserved2 = 0;
+   color.reserved3 = 0;
+   ifzero( color.postdate ) color.postdate = 5;
+   ifzero( color.postname ) color.postname = 6;
+   ifzero( color.posttext ) color.posttext = 2;
+   ifzero( color.postfrienddate ) color.postfrienddate = 5;
+   ifzero( color.postfriendname ) color.postfriendname = 1;
+   ifzero( color.postfriendtext ) color.postfriendtext = 2;
+   ifzero( color.anonymous ) color.anonymous = 3;
+   ifzero( color.moreprompt ) color.moreprompt = 3;
+   color.reserved4 = 0;
+   color.reserved5 = 0;
    if ( clearall )
    {
-      color.background = '0';
+      color.background = 0;
    }
-   ifzero( color.input1 ) color.input1 = '2';
-   ifzero( color.input2 ) color.input2 = '6';
-   ifzero( color.expresstext ) color.expresstext = '2';
-   ifzero( color.expressname ) color.expressname = '2';
-   ifzero( color.expressfriendname ) color.expressfriendname = '2';
-   ifzero( color.expressfriendtext ) color.expressfriendtext = '2';
+   ifzero( color.input1 ) color.input1 = 2;
+   ifzero( color.input2 ) color.input2 = 6;
+   ifzero( color.expresstext ) color.expresstext = 2;
+   ifzero( color.expressname ) color.expressname = 2;
+   ifzero( color.expressfriendname ) color.expressfriendname = 2;
+   ifzero( color.expressfriendtext ) color.expressfriendtext = 2;
 }
 
-char ansiTransform( char inputChar )
+int colorValueFromLegacyDigit( int inputChar )
 {
+   if ( inputChar >= '0' && inputChar <= '9' )
+   {
+      return inputChar - '0';
+   }
+
+   return inputChar;
+}
+
+int colorValueToLegacyDigit( int colorValue )
+{
+   return colorValue + '0';
+}
+
+int ansiTransform( int inputChar )
+{
+   int transformedColor;
+
+   transformedColor = colorValueFromLegacyDigit( inputChar );
    switch ( inputChar )
    {
       case '6':
-         inputChar = color.number;
+         transformedColor = color.number;
          break;
       case '3':
-         inputChar = color.forum;
+         transformedColor = color.forum;
          break;
       case '2':
-         inputChar = color.text;
+         transformedColor = color.text;
          break;
       case '1':
-         inputChar = color.errorTextColor;
+         transformedColor = color.errorTextColor;
          break;
       default:
          break;
    }
 
-   return (char)inputChar;
+   return transformedColor;
 }
 
 void ansiTransformExpress( char *ptrText, size_t size )
@@ -114,13 +132,13 @@ void ansiTransformExpress( char *ptrText, size_t size )
 
    if ( slistFind( friendList, ptrExpressSender, fStrCompareVoid ) != -1 )
    {
-      snprintf( aryTempText, sizeof( aryTempText ), "\033[3%cm%s \033[3%cm%s\033[3%cm %s\033[3%cm",
+      snprintf( aryTempText, sizeof( aryTempText ), "\033[3%dm%s \033[3%dm%s\033[3%dm %s\033[3%dm",
                 color.expressfriendtext, ptrText, color.expressfriendname, ptrExpressSender,
                 color.expressfriendtext, ptrExpressMarker, color.text );
    }
    else
    {
-      snprintf( aryTempText, sizeof( aryTempText ), "\033[3%cm%s \033[3%cm%s\033[3%cm %s\033[3%cm",
+      snprintf( aryTempText, sizeof( aryTempText ), "\033[3%dm%s \033[3%dm%s\033[3%dm %s\033[3%dm",
                 color.expresstext, ptrText, color.expressname, ptrExpressSender,
                 color.expresstext, ptrExpressMarker, color.text );
    }
@@ -128,35 +146,39 @@ void ansiTransformExpress( char *ptrText, size_t size )
    snprintf( ptrText, size, "%s", aryTempText );
 }
 
-char ansiTransformPost( char inputChar, int isFriend )
+int ansiTransformPost( int inputChar, int isFriend )
 {
+   int transformedColor;
+
+   transformedColor = colorValueFromLegacyDigit( inputChar );
    switch ( inputChar )
    {
       case '3':
-         inputChar = color.moreprompt;
+         transformedColor = color.moreprompt;
          break;
       case '2':
          if ( isFriend )
          {
-            inputChar = color.postfriendtext;
+            transformedColor = color.postfriendtext;
          }
          else
          {
-            inputChar = color.posttext;
+            transformedColor = color.posttext;
          }
          break;
       case '1':
-         inputChar = color.errorTextColor;
+         transformedColor = color.errorTextColor;
          break;
       default:
          break;
    }
-   return (char)inputChar;
+   return transformedColor;
 }
 
 void ansiTransformPostHeader( char *ptrText, int isFriend )
 {
    char *ptrScan;
+   int transformedColor;
 
    /* Would have been easier with strtok() but can't guarantee it exists. */
    for ( ptrScan = ptrText; *ptrScan; ptrScan++ )
@@ -172,33 +194,42 @@ void ansiTransformPostHeader( char *ptrText, int isFriend )
             case '6':
                if ( isFriend )
                {
-                  *ptrScan = color.postfriendname;
+                  transformedColor = color.postfriendname;
                }
                else
                {
-                  *ptrScan = color.postname;
+                  transformedColor = color.postname;
                }
                break;
             case '5':
-               *ptrScan = color.postdate;
+               if ( isFriend )
+               {
+                  transformedColor = color.postfrienddate;
+               }
+               else
+               {
+                  transformedColor = color.postdate;
+               }
                break;
             case '3':
-               *ptrScan = color.anonymous;
+               transformedColor = color.anonymous;
                break;
             case '2':
                if ( isFriend )
                {
-                  *ptrScan = color.postfriendtext;
+                  transformedColor = color.postfriendtext;
                }
                else
                {
-                  *ptrScan = color.posttext;
+                  transformedColor = color.posttext;
                }
                break;
             default:
+               transformedColor = colorValueFromLegacyDigit( *ptrScan );
                break;
          }
-         lastColor = *ptrScan;
+         *ptrScan = (char)colorValueToLegacyDigit( transformedColor );
+         lastColor = transformedColor;
       }
    }
 }
@@ -272,17 +303,17 @@ void colorOptions( void )
    flagsConfiguration.useBold = (unsigned int)yesNoDefault( flagsConfiguration.useBold );
    if ( flagsConfiguration.useAnsi )
    {
-      printf( "\033[%cm\033[3%c;4%cm", flagsConfiguration.useBold ? '1' : '0', lastColor,
+      printf( "\033[%cm\033[3%d;4%dm", flagsConfiguration.useBold ? '1' : '0', lastColor,
               color.background );
    }
 }
 
 #define A_USER "Example User"
 #define A_FRIEND "Example Friend"
-#define GEN_FMT_STR "\033[4%c;3%cmLobby> \033[3%cmEnter message\r\n\n\033[3%cmOnly Sysops may post to the lobby\r\n\n\033[3%cmLobby> \033[3%cmGoto \033[3%cm[Babble]  \033[3%cm150\033[3%cm messages, \033[3%cm1\033[3%cm new\r\n"
-#define POST_FMT_STR "\033[3%cmJan  1, 2000 11:01\033[3%cm from \033[3%cm%s\033[3%cm\r\nHi there!\r\n\033[3%cm[Lobby> msg #1]\r\n"
-#define EXPRESS_FMT_STR "\033[3%cm*** Message (#1) from \033[3%cm%s\033[3%cm at 11:01 ***\r\n>Hi there!\r\n"
-#define INPUT_FMT_STR "\033[3%cmMessage eXpress\r\nRecipient: \033[3%cmExam\033[3%cmple User\r\n\033[3%cm>Hi there!\r\n\033[3%cmMessage received by Example User.\r\n"
+#define GEN_FMT_STR "\033[4%d;3%dmLobby> \033[3%dmEnter message\r\n\n\033[3%dmOnly Sysops may post to the lobby\r\n\n\033[3%dmLobby> \033[3%dmGoto \033[3%dm[Babble]  \033[3%dm150\033[3%dm messages, \033[3%dm1\033[3%dm new\r\n"
+#define POST_FMT_STR "\033[3%dmJan  1, 2000 11:01\033[3%dm from \033[3%dm%s\033[3%dm\r\nHi there!\r\n\033[3%dm[Lobby> msg #1]\r\n"
+#define EXPRESS_FMT_STR "\033[3%dm*** Message (#1) from \033[3%dm%s\033[3%dm at 11:01 ***\r\n>Hi there!\r\n"
+#define INPUT_FMT_STR "\033[3%dmMessage eXpress\r\nRecipient: \033[3%dmExam\033[3%dmple User\r\n\033[3%dm>Hi there!\r\n\033[3%dmMessage received by Example User.\r\n"
 
 void generalColorConfig( void )
 {
@@ -614,7 +645,7 @@ char userOrFriend( void )
    return (char)inputChar;
 }
 
-char colorPicker( void )
+int colorPicker( void )
 {
    int inputChar;
    char aryPromptText[100];
@@ -628,51 +659,51 @@ char colorPicker( void )
    {
       case 'r':
          stdPrintf( "Red\r\n\n" );
-         inputChar = '1';
+         inputChar = 1;
          break;
       case 'g':
          stdPrintf( "Green\r\n\n" );
-         inputChar = '2';
+         inputChar = 2;
          break;
       case 'y':
          stdPrintf( "Yellow\r\n\n" );
-         inputChar = '3';
+         inputChar = 3;
          break;
       case 'b':
          stdPrintf( "Blue\r\n\n" );
-         inputChar = '4';
+         inputChar = 4;
          break;
       case 'm':
       case 'p': /* Some people call it purple */
          stdPrintf( "Magenta\r\n\n" );
-         inputChar = '5';
+         inputChar = 5;
          break;
       case 'c':
          stdPrintf( "Cyan\r\n\n" );
-         inputChar = '6';
+         inputChar = 6;
          break;
       case 'w':
          stdPrintf( "White\r\n\n" );
-         inputChar = '7';
+         inputChar = 7;
          break;
       case 'k':
          stdPrintf( "Black\r\n\n" );
-         inputChar = '0';
+         inputChar = 0;
          break;
       default:
-         inputChar = '0'; /* If your text goes black it's a bug here */
+         inputChar = 0; /* If your text goes black it's a bug here */
          break;
    }
 
-   return (char)inputChar;
+   return inputChar;
 }
 
-char backgroundPicker( void )
+int backgroundPicker( void )
 {
    int inputChar;
    char aryPromptText[140];
 
-   snprintf( aryPromptText, sizeof( aryPromptText ), "@C@kBlac@Yk @r @WR@Ced @g @WG@Yreen @y @WY@Cellow @b @YB@Ylue @m @WM@Yagenta @c @WC@Yyan @w @YW@Bhite @d @YD@Cefault \033[4%cm @Y-> @G",
+   snprintf( aryPromptText, sizeof( aryPromptText ), "@C@kBlac@Yk @r @WR@Ced @g @WG@Yreen @y @WY@Cellow @b @YB@Ylue @m @WM@Yagenta @c @WC@Yyan @w @YW@Bhite @d @YD@Cefault \033[4%dm @Y-> @G",
              color.background );
    colorize( aryPromptText );
 
@@ -682,46 +713,46 @@ char backgroundPicker( void )
    {
       case 'k':
          stdPrintf( "Black\r\n" );
-         inputChar = '0';
+         inputChar = 0;
          break;
       case 'r':
          stdPrintf( "Red\r\n" );
-         inputChar = '1';
+         inputChar = 1;
          break;
       case 'g':
          stdPrintf( "Green\r\n" );
-         inputChar = '2';
+         inputChar = 2;
          break;
       case 'y':
          stdPrintf( "Yellow\r\n" );
-         inputChar = '3';
+         inputChar = 3;
          break;
       case 'b':
          stdPrintf( "Blue\r\n" );
-         inputChar = '4';
+         inputChar = 4;
          break;
       case 'm':
       case 'p': /* Some people call it purple */
          stdPrintf( "Magenta\r\n" );
-         inputChar = '5';
+         inputChar = 5;
          break;
       case 'c':
          stdPrintf( "Cyan\r\n" );
-         inputChar = '6';
+         inputChar = 6;
          break;
       case 'w':
          stdPrintf( "White\r\n" );
-         inputChar = '7';
+         inputChar = 7;
          break;
       case 'd':
          stdPrintf( "Default\r\n" );
-         inputChar = '9';
+         inputChar = 9;
          break;
       default:
-         inputChar = '0'; /* If your text goes black it's a bug here */
+         inputChar = 0; /* If your text goes black it's a bug here */
          break;
    }
-   stdPrintf( "\033[4%cm\n", inputChar );
+   stdPrintf( "\033[4%dm\n", inputChar );
 
-   return (char)inputChar;
+   return inputChar;
 }

--- a/color.c
+++ b/color.c
@@ -58,7 +58,7 @@ static bool isColorNameMatch( const char *ptrLeft, const char *ptrRight )
  * which might use those reserved fields - they will get their default values
  * instead of zero, which would render as black.
  */
-#define ifzero( x ) if ( ( x ) < 1 || ( x ) > 7 || clearall )
+#define ifzero( x ) if ( ( x ) < 0 || clearall )
 void defaultColors( int clearall )
 {
    ifzero( color.text ) color.text = 2;

--- a/color.c
+++ b/color.c
@@ -140,6 +140,98 @@ const char *colorNameFromValue( int colorValue )
    return NULL;
 }
 
+static void printAnsiForegroundColor( int colorValue )
+{
+   char aryAnsiSequence[32];
+
+   formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                 colorValue );
+   stdPrintf( "%s", aryAnsiSequence );
+}
+
+static void printAnsiBackgroundColor( int colorValue )
+{
+   char aryAnsiSequence[32];
+
+   formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                 colorValue );
+   stdPrintf( "%s", aryAnsiSequence );
+}
+
+static void printAnsiDisplayState( int foregroundColor, int backgroundColor )
+{
+   char aryAnsiSequence[32];
+
+   formatAnsiDisplayStateSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                   foregroundColor, backgroundColor,
+                                   flagsConfiguration.useBold );
+   stdPrintf( "%s", aryAnsiSequence );
+}
+
+static void printGeneralColorPreview( void )
+{
+   printAnsiDisplayState( color.forum, color.background );
+   stdPrintf( "Lobby> " );
+   printAnsiForegroundColor( color.text );
+   stdPrintf( "Enter message\r\n\n" );
+   printAnsiForegroundColor( color.errorTextColor );
+   stdPrintf( "Only Sysops may post to the lobby\r\n\n" );
+   printAnsiForegroundColor( color.forum );
+   stdPrintf( "Lobby> " );
+   printAnsiForegroundColor( color.text );
+   stdPrintf( "Goto " );
+   printAnsiForegroundColor( color.forum );
+   stdPrintf( "[Babble]  " );
+   printAnsiForegroundColor( color.number );
+   stdPrintf( "150" );
+   printAnsiForegroundColor( color.text );
+   stdPrintf( " messages, " );
+   printAnsiForegroundColor( color.number );
+   stdPrintf( "1" );
+   printAnsiForegroundColor( color.text );
+   stdPrintf( " new\r\n" );
+}
+
+static void printPostColorPreview( int dateColor, int textColor,
+                                   int nameColor, const char *ptrName )
+{
+   printAnsiForegroundColor( dateColor );
+   stdPrintf( "Jan  1, 2000 11:01" );
+   printAnsiForegroundColor( textColor );
+   stdPrintf( " from " );
+   printAnsiForegroundColor( nameColor );
+   stdPrintf( "%s", ptrName );
+   printAnsiForegroundColor( textColor );
+   stdPrintf( "\r\nHi there!\r\n" );
+   printAnsiForegroundColor( color.forum );
+   stdPrintf( "[Lobby> msg #1]\r\n" );
+}
+
+static void printExpressColorPreview( int textColor, int nameColor,
+                                      const char *ptrName )
+{
+   printAnsiForegroundColor( textColor );
+   stdPrintf( "*** Message (#1) from " );
+   printAnsiForegroundColor( nameColor );
+   stdPrintf( "%s", ptrName );
+   printAnsiForegroundColor( textColor );
+   stdPrintf( " at 11:01 ***\r\n>Hi there!\r\n" );
+}
+
+static void printInputColorPreview( void )
+{
+   printAnsiForegroundColor( color.text );
+   stdPrintf( "Message eXpress\r\nRecipient: " );
+   printAnsiForegroundColor( color.input1 );
+   stdPrintf( "Exam" );
+   printAnsiForegroundColor( color.input2 );
+   stdPrintf( "ple User\r\n" );
+   printAnsiForegroundColor( color.input1 );
+   stdPrintf( ">Hi there!\r\n" );
+   printAnsiForegroundColor( color.text );
+   stdPrintf( "Message received by Example User.\r\n" );
+}
+
 int ansiTransform( int inputChar )
 {
    int transformedColor;
@@ -169,6 +261,9 @@ int ansiTransform( int inputChar )
 void ansiTransformExpress( char *ptrText, size_t size )
 {
    char aryTempText[580];
+   char aryMessageColor[32];
+   char aryNameColor[32];
+   char aryResetColor[32];
    char *ptrExpressSender, *ptrExpressMarker;
 
    /* Insert color only when ANSI is being used */
@@ -201,16 +296,23 @@ void ansiTransformExpress( char *ptrText, size_t size )
 
    if ( slistFind( friendList, ptrExpressSender, fStrCompareVoid ) != -1 )
    {
-      snprintf( aryTempText, sizeof( aryTempText ), "\033[3%dm%s \033[3%dm%s\033[3%dm %s\033[3%dm",
-                color.expressfriendtext, ptrText, color.expressfriendname, ptrExpressSender,
-                color.expressfriendtext, ptrExpressMarker, color.text );
+      formatAnsiForegroundSequence( aryMessageColor, sizeof( aryMessageColor ),
+                                    color.expressfriendtext );
+      formatAnsiForegroundSequence( aryNameColor, sizeof( aryNameColor ),
+                                    color.expressfriendname );
    }
    else
    {
-      snprintf( aryTempText, sizeof( aryTempText ), "\033[3%dm%s \033[3%dm%s\033[3%dm %s\033[3%dm",
-                color.expresstext, ptrText, color.expressname, ptrExpressSender,
-                color.expresstext, ptrExpressMarker, color.text );
+      formatAnsiForegroundSequence( aryMessageColor, sizeof( aryMessageColor ),
+                                    color.expresstext );
+      formatAnsiForegroundSequence( aryNameColor, sizeof( aryNameColor ),
+                                    color.expressname );
    }
+   formatAnsiForegroundSequence( aryResetColor, sizeof( aryResetColor ),
+                                 color.text );
+   snprintf( aryTempText, sizeof( aryTempText ), "%s%s %s%s%s %s%s",
+             aryMessageColor, ptrText, aryNameColor, ptrExpressSender,
+             aryMessageColor, ptrExpressMarker, aryResetColor );
    lastColor = color.text;
    snprintf( ptrText, size, "%s", aryTempText );
 }
@@ -372,17 +474,12 @@ void colorOptions( void )
    flagsConfiguration.useBold = (unsigned int)yesNoDefault( flagsConfiguration.useBold );
    if ( flagsConfiguration.useAnsi )
    {
-      printf( "\033[%cm\033[3%d;4%dm", flagsConfiguration.useBold ? '1' : '0', lastColor,
-              color.background );
+      printAnsiDisplayState( lastColor, color.background );
    }
 }
 
 #define A_USER "Example User"
 #define A_FRIEND "Example Friend"
-#define GEN_FMT_STR "\033[4%d;3%dmLobby> \033[3%dmEnter message\r\n\n\033[3%dmOnly Sysops may post to the lobby\r\n\n\033[3%dmLobby> \033[3%dmGoto \033[3%dm[Babble]  \033[3%dm150\033[3%dm messages, \033[3%dm1\033[3%dm new\r\n"
-#define POST_FMT_STR "\033[3%dmJan  1, 2000 11:01\033[3%dm from \033[3%dm%s\033[3%dm\r\nHi there!\r\n\033[3%dm[Lobby> msg #1]\r\n"
-#define EXPRESS_FMT_STR "\033[3%dm*** Message (#1) from \033[3%dm%s\033[3%dm at 11:01 ***\r\n>Hi there!\r\n"
-#define INPUT_FMT_STR "\033[3%dmMessage eXpress\r\nRecipient: \033[3%dmExam\033[3%dmple User\r\n\033[3%dm>Hi there!\r\n\033[3%dmMessage received by Example User.\r\n"
 
 void generalColorConfig( void )
 {
@@ -390,10 +487,7 @@ void generalColorConfig( void )
 
    while ( true )
    {
-      stdPrintf( GEN_FMT_STR, color.background, color.forum,
-                 color.text, color.errorTextColor, color.forum,
-                 color.text, color.forum, color.number,
-                 color.text, color.number, color.text );
+      printGeneralColorPreview();
 
       snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n@YB@Cackground  @YE@Crror  @YF@Corum  @YN@Cumber  @YT@Cext  @YQ@Cuit@Y -> @G" );
       colorize( aryPromptText );
@@ -440,8 +534,7 @@ void inputColorConfig( void )
 
    while ( true )
    {
-      stdPrintf( INPUT_FMT_STR, color.text, color.input1,
-                 color.input2, color.input1, color.text );
+      printInputColorPreview();
 
       snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n@YT@Cext  @YC@Completion  @YQ@Cuit@Y -> @G" );
       colorize( aryPromptText );
@@ -494,8 +587,8 @@ void postUserColorConfig( void )
    {
       int menuOption;
 
-      stdPrintf( POST_FMT_STR, color.postdate, color.posttext,
-                 color.postname, A_USER, color.posttext, color.forum );
+      printPostColorPreview( color.postdate, color.posttext,
+                             color.postname, A_USER );
       menuOption = postColorMenu();
       switch ( menuOption )
       {
@@ -525,9 +618,8 @@ void postFriendColorConfig( void )
    {
       int menuOption;
 
-      stdPrintf( POST_FMT_STR, color.postfrienddate, color.postfriendtext,
-                 color.postfriendname, A_FRIEND, color.postfriendtext,
-                 color.forum );
+      printPostColorPreview( color.postfrienddate, color.postfriendtext,
+                             color.postfriendname, A_FRIEND );
       menuOption = postColorMenu();
       switch ( menuOption )
       {
@@ -608,8 +700,8 @@ void expressUserColorConfig( void )
    {
       int menuOption;
 
-      stdPrintf( EXPRESS_FMT_STR, color.expresstext,
-                 color.expressname, A_USER, color.expresstext );
+      printExpressColorPreview( color.expresstext, color.expressname,
+                                A_USER );
       menuOption = expressColorMenu();
       switch ( menuOption )
       {
@@ -636,8 +728,8 @@ void expressFriendColorConfig( void )
    {
       int menuOption;
 
-      stdPrintf( EXPRESS_FMT_STR, color.expressfriendtext,
-                 color.expressfriendname, A_FRIEND, color.expressfriendtext );
+      printExpressColorPreview( color.expressfriendtext,
+                                color.expressfriendname, A_FRIEND );
       menuOption = expressColorMenu();
       switch ( menuOption )
       {
@@ -772,9 +864,10 @@ int backgroundPicker( void )
    int inputChar;
    char aryPromptText[140];
 
-   snprintf( aryPromptText, sizeof( aryPromptText ), "@C@kBlac@Yk @r @WR@Ced @g @WG@Yreen @y @WY@Cellow @b @YB@Ylue @m @WM@Yagenta @c @WC@Yyan @w @YW@Bhite @d @YD@Cefault \033[4%dm @Y-> @G",
-             color.background );
+   snprintf( aryPromptText, sizeof( aryPromptText ), "@C@kBlac@Yk @r @WR@Ced @g @WG@Yreen @y @WY@Cellow @b @YB@Ylue @m @WM@Yagenta @c @WC@Yyan @w @YW@Bhite @d @YD@Cefault " );
    colorize( aryPromptText );
+   printAnsiBackgroundColor( color.background );
+   colorize( " @Y-> @G" );
 
    inputChar = readValidatedMenuKey( COLOR_BACKGROUND_KEYS );
 
@@ -821,7 +914,8 @@ int backgroundPicker( void )
          inputChar = 0; /* If your text goes black it's a bug here */
          break;
    }
-   stdPrintf( "\033[4%dm\n", inputChar );
+   printAnsiBackgroundColor( inputChar );
+   stdPrintf( "\n" );
 
    return inputChar;
 }

--- a/color.c
+++ b/color.c
@@ -13,14 +13,21 @@ static const char *COLOR_INPUT_MENU_KEYS = "ctq \n";
 static const char *COLOR_POST_MENU_KEYS = "dntq \n";
 static const char *COLOR_EXPRESS_MENU_KEYS = "ntq \n";
 static const char *COLOR_USER_OR_FRIEND_KEYS = "ufq \n";
-static const char *COLOR_FOREGROUND_KEYS = "krgybmcw";
-static const char *COLOR_BACKGROUND_KEYS = "krgybmcwd";
+static const char *COLOR_FOREGROUND_KEYS = "krgybmcw12345678";
+static const char *COLOR_BACKGROUND_KEYS = "krgybmcwd12345678";
 
 typedef struct
 {
    const char *ptrName;
    int colorValue;
 } NamedColorSpec;
+
+typedef struct
+{
+   int keyChar;
+   int colorValue;
+   const char *ptrDisplayName;
+} PickerColorOption;
 
 static const NamedColorSpec aryNamedColors[] =
    {
@@ -43,6 +50,45 @@ static const NamedColorSpec aryNamedColors[] =
       { "cyan", 44 },
       { "white", 231 },
       { "default", COLOR_VALUE_DEFAULT } };
+
+static const PickerColorOption aryForegroundPickerOptions[] =
+   {
+      { 'k', 0, "Black" },
+      { 'r', 1, "Red" },
+      { 'g', 2, "Green" },
+      { 'y', 3, "Yellow" },
+      { 'b', 4, "Blue" },
+      { 'm', 5, "Magenta" },
+      { 'c', 6, "Cyan" },
+      { 'w', 7, "White" },
+      { '1', 8, "Bright black" },
+      { '2', 9, "Bright red" },
+      { '3', 10, "Bright green" },
+      { '4', 11, "Bright yellow" },
+      { '5', 12, "Bright blue" },
+      { '6', 13, "Bright magenta" },
+      { '7', 14, "Bright cyan" },
+      { '8', 15, "Bright white" } };
+
+static const PickerColorOption aryBackgroundPickerOptions[] =
+   {
+      { 'k', 0, "Black" },
+      { 'r', 1, "Red" },
+      { 'g', 2, "Green" },
+      { 'y', 3, "Yellow" },
+      { 'b', 4, "Blue" },
+      { 'm', 5, "Magenta" },
+      { 'c', 6, "Cyan" },
+      { 'w', 7, "White" },
+      { '1', 8, "Bright black" },
+      { '2', 9, "Bright red" },
+      { '3', 10, "Bright green" },
+      { '4', 11, "Bright yellow" },
+      { '5', 12, "Bright blue" },
+      { '6', 13, "Bright magenta" },
+      { '7', 14, "Bright cyan" },
+      { '8', 15, "Bright white" },
+      { 'd', COLOR_VALUE_DEFAULT, "Default" } };
 
 static bool isColorNameMatch( const char *ptrLeft, const char *ptrRight )
 {
@@ -114,6 +160,25 @@ int colorValueToLegacyDigit( int colorValue )
    return colorValue + '0';
 }
 
+int formatTransformedAnsiForegroundSequence( char *ptrBuffer, size_t bufferSize,
+                                             int inputChar, int isPostContext,
+                                             int isFriend )
+{
+   int transformedColor;
+
+   if ( isPostContext )
+   {
+      transformedColor = ansiTransformPost( inputChar, isFriend );
+   }
+   else
+   {
+      transformedColor = ansiTransform( inputChar );
+   }
+
+   lastColor = transformedColor;
+   return formatAnsiForegroundSequence( ptrBuffer, bufferSize, transformedColor );
+}
+
 int colorValueFromName( const char *ptrColorName )
 {
    size_t itemIndex;
@@ -149,6 +214,42 @@ const char *colorNameFromValue( int colorValue )
    return NULL;
 }
 
+static const PickerColorOption *findPickerColorOption( const PickerColorOption *ptrOptions,
+                                                       size_t itemCount,
+                                                       int keyChar )
+{
+   size_t itemIndex;
+
+   for ( itemIndex = 0; itemIndex < itemCount; itemIndex++ )
+   {
+      if ( ptrOptions[itemIndex].keyChar == keyChar )
+      {
+         return &ptrOptions[itemIndex];
+      }
+   }
+
+   return NULL;
+}
+
+static void printForegroundPickerMenu( void )
+{
+   colorize( "\r\n@Y[K]@C Black           @Y[R]@C Red             @Y[G]@C Green           @Y[Y]@C Yellow\r\n" );
+   colorize( "@Y[B]@C Blue            @Y[M]@C Magenta         @Y[C]@C Cyan            @Y[W]@C White\r\n" );
+   colorize( "@Y[1]@C Bright black   @Y[2]@C Bright red      @Y[3]@C Bright green    @Y[4]@C Bright yellow\r\n" );
+   colorize( "@Y[5]@C Bright blue    @Y[6]@C Bright magenta  @Y[7]@C Bright cyan     @Y[8]@C Bright white\r\n" );
+   colorize( "@YSelect color -> @G" );
+}
+
+static void printBackgroundPickerMenu( void )
+{
+   colorize( "\r\n@Y[K]@C Black           @Y[R]@C Red             @Y[G]@C Green           @Y[Y]@C Yellow\r\n" );
+   colorize( "@Y[B]@C Blue            @Y[M]@C Magenta         @Y[C]@C Cyan            @Y[W]@C White\r\n" );
+   colorize( "@Y[1]@C Bright black   @Y[2]@C Bright red      @Y[3]@C Bright green    @Y[4]@C Bright yellow\r\n" );
+   colorize( "@Y[5]@C Bright blue    @Y[6]@C Bright magenta  @Y[7]@C Bright cyan     @Y[8]@C Bright white\r\n" );
+   colorize( "@Y[D]@C Default\r\n" );
+   colorize( "@YSelect background -> @G" );
+}
+
 static void printAnsiForegroundColor( int colorValue )
 {
    char aryAnsiSequence[32];
@@ -175,6 +276,35 @@ static void printAnsiDisplayState( int foregroundColor, int backgroundColor )
                                    foregroundColor, backgroundColor,
                                    flagsConfiguration.useBold );
    stdPrintf( "%s", aryAnsiSequence );
+}
+
+static int transformPostHeaderColor( int inputChar, int isFriend )
+{
+   switch ( inputChar )
+   {
+      case '6':
+         if ( isFriend )
+         {
+            return color.postfriendname;
+         }
+         return color.postname;
+      case '5':
+         if ( isFriend )
+         {
+            return color.postfrienddate;
+         }
+         return color.postdate;
+      case '3':
+         return color.anonymous;
+      case '2':
+         if ( isFriend )
+         {
+            return color.postfriendtext;
+         }
+         return color.posttext;
+      default:
+         return colorValueFromLegacyDigit( inputChar );
+   }
 }
 
 static void printGeneralColorPreview( void )
@@ -355,63 +485,36 @@ int ansiTransformPost( int inputChar, int isFriend )
    return transformedColor;
 }
 
-void ansiTransformPostHeader( char *ptrText, int isFriend )
+void ansiTransformPostHeader( char *ptrText, size_t bufferSize, int isFriend )
 {
+   char aryTransformedHeader[320];
+   char aryAnsiSequence[32];
    char *ptrScan;
-   int transformedColor;
+   size_t writeOffset;
 
-   /* Would have been easier with strtok() but can't guarantee it exists. */
-   for ( ptrScan = ptrText; *ptrScan; ptrScan++ )
+   writeOffset = 0;
+
+   /* Rewrite simple ESC[3xm foreground sequences into full palette-aware ANSI. */
+   for ( ptrScan = ptrText; *ptrScan != '\0' && writeOffset < sizeof( aryTransformedHeader ) - 1; )
    {
-      /* Find an ANSI code */
-      if ( *ptrScan == 27 )
+      if ( ptrScan[0] == '\033' && ptrScan[1] == '[' && ptrScan[2] == '3' &&
+           ptrScan[3] != '\0' && ptrScan[4] == 'm' )
       {
-         /* transform ANSI code */
-         ptrScan += 3;
-
-         switch ( *ptrScan )
-         {
-            case '6':
-               if ( isFriend )
-               {
-                  transformedColor = color.postfriendname;
-               }
-               else
-               {
-                  transformedColor = color.postname;
-               }
-               break;
-            case '5':
-               if ( isFriend )
-               {
-                  transformedColor = color.postfrienddate;
-               }
-               else
-               {
-                  transformedColor = color.postdate;
-               }
-               break;
-            case '3':
-               transformedColor = color.anonymous;
-               break;
-            case '2':
-               if ( isFriend )
-               {
-                  transformedColor = color.postfriendtext;
-               }
-               else
-               {
-                  transformedColor = color.posttext;
-               }
-               break;
-            default:
-               transformedColor = colorValueFromLegacyDigit( *ptrScan );
-               break;
-         }
-         *ptrScan = (char)colorValueToLegacyDigit( transformedColor );
-         lastColor = transformedColor;
+         lastColor = transformPostHeaderColor( ptrScan[3], isFriend );
+         formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                       lastColor );
+         writeOffset += (size_t)snprintf( aryTransformedHeader + writeOffset,
+                                          sizeof( aryTransformedHeader ) - writeOffset,
+                                          "%s", aryAnsiSequence );
+         ptrScan += 5;
+         continue;
       }
+
+      aryTransformedHeader[writeOffset++] = *ptrScan++;
    }
+
+   aryTransformedHeader[writeOffset] = '\0';
+   snprintf( ptrText, bufferSize, "%s", aryTransformedHeader );
 }
 
 void colorConfig( void )
@@ -817,114 +920,43 @@ char userOrFriend( void )
 
 int colorPicker( void )
 {
+   const PickerColorOption *ptrOption;
    int inputChar;
-   char aryPromptText[100];
 
-   snprintf( aryPromptText, sizeof( aryPromptText ), "@CBlac@Yk  @YR@Red  @YG@Green  @WY@Yellow  @YB@Blue  @YM@Magenta  @YC@Cyan  @YW@White @Y-> @G" );
-   colorize( aryPromptText );
+   printForegroundPickerMenu();
 
    inputChar = readValidatedMenuKey( COLOR_FOREGROUND_KEYS );
-
-   switch ( inputChar )
+   ptrOption = findPickerColorOption( aryForegroundPickerOptions,
+                                      sizeof( aryForegroundPickerOptions ) / sizeof( aryForegroundPickerOptions[0] ),
+                                      inputChar );
+   if ( ptrOption == NULL )
    {
-      case 'r':
-         stdPrintf( "Red\r\n\n" );
-         inputChar = 1;
-         break;
-      case 'g':
-         stdPrintf( "Green\r\n\n" );
-         inputChar = 2;
-         break;
-      case 'y':
-         stdPrintf( "Yellow\r\n\n" );
-         inputChar = 3;
-         break;
-      case 'b':
-         stdPrintf( "Blue\r\n\n" );
-         inputChar = 4;
-         break;
-      case 'm':
-      case 'p': /* Some people call it purple */
-         stdPrintf( "Magenta\r\n\n" );
-         inputChar = 5;
-         break;
-      case 'c':
-         stdPrintf( "Cyan\r\n\n" );
-         inputChar = 6;
-         break;
-      case 'w':
-         stdPrintf( "White\r\n\n" );
-         inputChar = 7;
-         break;
-      case 'k':
-         stdPrintf( "Black\r\n\n" );
-         inputChar = 0;
-         break;
-      default:
-         inputChar = 0; /* If your text goes black it's a bug here */
-         break;
+      return 0;
    }
 
-   return inputChar;
+   stdPrintf( "%s\r\n\n", ptrOption->ptrDisplayName );
+   return ptrOption->colorValue;
 }
 
 int backgroundPicker( void )
 {
+   const PickerColorOption *ptrOption;
    int inputChar;
-   char aryPromptText[140];
 
-   snprintf( aryPromptText, sizeof( aryPromptText ), "@C@kBlac@Yk @r @WR@Ced @g @WG@Yreen @y @WY@Cellow @b @YB@Ylue @m @WM@Yagenta @c @WC@Yyan @w @YW@Bhite @d @YD@Cefault " );
-   colorize( aryPromptText );
-   printAnsiBackgroundColor( color.background );
-   colorize( " @Y-> @G" );
+   printBackgroundPickerMenu();
 
    inputChar = readValidatedMenuKey( COLOR_BACKGROUND_KEYS );
-
-   switch ( inputChar )
+   ptrOption = findPickerColorOption( aryBackgroundPickerOptions,
+                                      sizeof( aryBackgroundPickerOptions ) / sizeof( aryBackgroundPickerOptions[0] ),
+                                      inputChar );
+   if ( ptrOption == NULL )
    {
-      case 'k':
-         stdPrintf( "Black\r\n" );
-         inputChar = 0;
-         break;
-      case 'r':
-         stdPrintf( "Red\r\n" );
-         inputChar = 1;
-         break;
-      case 'g':
-         stdPrintf( "Green\r\n" );
-         inputChar = 2;
-         break;
-      case 'y':
-         stdPrintf( "Yellow\r\n" );
-         inputChar = 3;
-         break;
-      case 'b':
-         stdPrintf( "Blue\r\n" );
-         inputChar = 4;
-         break;
-      case 'm':
-      case 'p': /* Some people call it purple */
-         stdPrintf( "Magenta\r\n" );
-         inputChar = 5;
-         break;
-      case 'c':
-         stdPrintf( "Cyan\r\n" );
-         inputChar = 6;
-         break;
-      case 'w':
-         stdPrintf( "White\r\n" );
-         inputChar = 7;
-         break;
-      case 'd':
-         stdPrintf( "Default\r\n" );
-         inputChar = COLOR_VALUE_DEFAULT;
-         break;
-      default:
-         inputChar = 0; /* If your text goes black it's a bug here */
-         break;
+      return 0;
    }
-   printAnsiBackgroundColor( inputChar );
+
+   stdPrintf( "%s\r\n", ptrOption->ptrDisplayName );
+   printAnsiBackgroundColor( ptrOption->colorValue );
    stdPrintf( "\n" );
 
-   return inputChar;
+   return ptrOption->colorValue;
 }

--- a/color.c
+++ b/color.c
@@ -7,11 +7,12 @@
 #include "defs.h"
 #include "ext.h"
 
-static const char *COLOR_MAIN_MENU_KEYS = "gipxorq \n";
+static const char *COLOR_MAIN_MENU_KEYS = "gipsoxq \n";
 static const char *COLOR_GENERAL_MENU_KEYS = "befntq \n";
 static const char *COLOR_INPUT_MENU_KEYS = "ctq \n";
 static const char *COLOR_POST_MENU_KEYS = "dntq \n";
 static const char *COLOR_EXPRESS_MENU_KEYS = "ntq \n";
+static const char *COLOR_RESET_MENU_KEYS = "dcq \n";
 static const char *COLOR_USER_OR_FRIEND_KEYS = "ufq \n";
 static const char *COLOR_FOREGROUND_KEYS = "krgybmcw12345678";
 static const char *COLOR_BACKGROUND_KEYS = "krgybmcwd12345678";
@@ -248,6 +249,62 @@ static void printBackgroundPickerMenu( void )
    colorize( "@Y[5]@C Bright blue    @Y[6]@C Bright magenta  @Y[7]@C Bright cyan     @Y[8]@C Bright white\r\n" );
    colorize( "@Y[D]@C Default\r\n" );
    colorize( "@YSelect background -> @G" );
+}
+
+void colorblindColors( void )
+{
+   color.text = 231;
+   color.forum = 75;
+   color.number = 214;
+   color.errorTextColor = 166;
+   color.reserved1 = 16;
+   color.reserved2 = 16;
+   color.reserved3 = 16;
+   color.postdate = 75;
+   color.postname = 214;
+   color.posttext = 231;
+   color.postfrienddate = 25;
+   color.postfriendname = 175;
+   color.postfriendtext = 231;
+   color.anonymous = 221;
+   color.moreprompt = 221;
+   color.reserved4 = 16;
+   color.reserved5 = 16;
+   color.background = 16;
+   color.input1 = 231;
+   color.input2 = 36;
+   color.expresstext = 231;
+   color.expressname = 214;
+   color.expressfriendname = 175;
+   color.expressfriendtext = 231;
+}
+
+static void presetColorConfig( void )
+{
+   stdPrintf( "Color presets\r\n\n" );
+   colorize( "@YD@Cefault  @YC@Colorblind  @YQ@Cuit@Y -> @G" );
+
+   switch ( readValidatedMenuKey( COLOR_RESET_MENU_KEYS ) )
+   {
+      case 'd':
+         stdPrintf( "Default\r\n" );
+         defaultColors( 1 );
+         break;
+
+      case 'c':
+         stdPrintf( "Colorblind\r\n" );
+         colorblindColors();
+         break;
+
+      case 'q':
+      case ' ':
+      case '\n':
+         stdPrintf( "Quit\r\n" );
+         break;
+
+      default:
+         break;
+   }
 }
 
 static void printAnsiForegroundColor( int colorValue )
@@ -528,7 +585,7 @@ void colorConfig( void )
    }
    while ( true )
    {
-      snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n@YG@Ceneral  @YI@Cnput  @YP@Costs  @YX@Cpress  @YO@Cptions  @YR@Ceset  @YQ@Cuit\r\n@YColor config -> @G" );
+      snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n@YG@Ceneral  @YI@Cnput  @YP@Costs  pre@YS@Cets  @YO@Cptions  @YX@Cpress  @YQ@Cuit\r\n@YColor config -> @G" );
       colorize( aryPromptText );
 
       int inputChar = readValidatedMenuKey( COLOR_MAIN_MENU_KEYS );
@@ -553,9 +610,8 @@ void colorConfig( void )
             postColorConfig();
             break;
 
-         case 'r':
-            stdPrintf( "Reset colors\r\n" );
-            defaultColors( 1 );
+         case 's':
+            presetColorConfig();
             break;
 
          case 'x':

--- a/color.c
+++ b/color.c
@@ -106,46 +106,6 @@ static bool isColorNameMatch( const char *ptrLeft, const char *ptrRight )
    return *ptrLeft == '\0' && *ptrRight == '\0';
 }
 
-/*
- * defaultColors is called once with an arg of 1 before the bbsrc file is
- * read.  This initializes all the color variables.  It is then called again
- * after the bbsrc file is read, with an arg of 0.  This helps with reserved
- * fields which might become used after a user upgrades to a later version
- * which might use those reserved fields - they will get their default values
- * instead of zero, which would render as black.
- */
-#define ifzero( x ) if ( ( x ) < 0 || clearall )
-void defaultColors( int clearall )
-{
-   ifzero( color.text ) color.text = 2;
-   ifzero( color.forum ) color.forum = 3;
-   ifzero( color.number ) color.number = 6;
-   ifzero( color.errorTextColor ) color.errorTextColor = 1;
-   color.reserved1 = 0;
-   color.reserved2 = 0;
-   color.reserved3 = 0;
-   ifzero( color.postdate ) color.postdate = 5;
-   ifzero( color.postname ) color.postname = 6;
-   ifzero( color.posttext ) color.posttext = 2;
-   ifzero( color.postfrienddate ) color.postfrienddate = 5;
-   ifzero( color.postfriendname ) color.postfriendname = 1;
-   ifzero( color.postfriendtext ) color.postfriendtext = 2;
-   ifzero( color.anonymous ) color.anonymous = 3;
-   ifzero( color.moreprompt ) color.moreprompt = 3;
-   color.reserved4 = 0;
-   color.reserved5 = 0;
-   if ( clearall )
-   {
-      color.background = 0;
-   }
-   ifzero( color.input1 ) color.input1 = 2;
-   ifzero( color.input2 ) color.input2 = 6;
-   ifzero( color.expresstext ) color.expresstext = 2;
-   ifzero( color.expressname ) color.expressname = 2;
-   ifzero( color.expressfriendname ) color.expressfriendname = 2;
-   ifzero( color.expressfriendtext ) color.expressfriendtext = 2;
-}
-
 int colorValueFromLegacyDigit( int inputChar )
 {
    if ( inputChar >= '0' && inputChar <= '9' )
@@ -249,62 +209,6 @@ static void printBackgroundPickerMenu( void )
    colorize( "@Y[5]@C Bright blue    @Y[6]@C Bright magenta  @Y[7]@C Bright cyan     @Y[8]@C Bright white\r\n" );
    colorize( "@Y[D]@C Default\r\n" );
    colorize( "@YSelect background -> @G" );
-}
-
-void colorblindColors( void )
-{
-   color.text = 231;
-   color.forum = 75;
-   color.number = 214;
-   color.errorTextColor = 166;
-   color.reserved1 = 16;
-   color.reserved2 = 16;
-   color.reserved3 = 16;
-   color.postdate = 75;
-   color.postname = 214;
-   color.posttext = 231;
-   color.postfrienddate = 25;
-   color.postfriendname = 175;
-   color.postfriendtext = 231;
-   color.anonymous = 221;
-   color.moreprompt = 221;
-   color.reserved4 = 16;
-   color.reserved5 = 16;
-   color.background = 16;
-   color.input1 = 231;
-   color.input2 = 36;
-   color.expresstext = 231;
-   color.expressname = 214;
-   color.expressfriendname = 175;
-   color.expressfriendtext = 231;
-}
-
-void hotDogColors( void )
-{
-   color.text = 220;
-   color.forum = 196;
-   color.number = 220;
-   color.errorTextColor = 231;
-   color.reserved1 = 16;
-   color.reserved2 = 16;
-   color.reserved3 = 16;
-   color.postdate = 226;
-   color.postname = 226;
-   color.posttext = 214;
-   color.postfrienddate = 226;
-   color.postfriendname = 226;
-   color.postfriendtext = 214;
-   color.anonymous = 226;
-   color.moreprompt = 220;
-   color.reserved4 = 16;
-   color.reserved5 = 16;
-   color.background = 16;
-   color.input1 = 220;
-   color.input2 = 231;
-   color.expresstext = 214;
-   color.expressname = 226;
-   color.expressfriendname = 226;
-   color.expressfriendtext = 214;
 }
 
 static void presetColorConfig( void )

--- a/color.c
+++ b/color.c
@@ -12,7 +12,7 @@ static const char *COLOR_GENERAL_MENU_KEYS = "befntq \n";
 static const char *COLOR_INPUT_MENU_KEYS = "ctq \n";
 static const char *COLOR_POST_MENU_KEYS = "dntq \n";
 static const char *COLOR_EXPRESS_MENU_KEYS = "ntq \n";
-static const char *COLOR_RESET_MENU_KEYS = "dcq \n";
+static const char *COLOR_RESET_MENU_KEYS = "dchq \n";
 static const char *COLOR_USER_OR_FRIEND_KEYS = "ufq \n";
 static const char *COLOR_FOREGROUND_KEYS = "krgybmcw12345678";
 static const char *COLOR_BACKGROUND_KEYS = "krgybmcwd12345678";
@@ -279,10 +279,38 @@ void colorblindColors( void )
    color.expressfriendtext = 231;
 }
 
+void hotDogColors( void )
+{
+   color.text = 220;
+   color.forum = 196;
+   color.number = 220;
+   color.errorTextColor = 231;
+   color.reserved1 = 16;
+   color.reserved2 = 16;
+   color.reserved3 = 16;
+   color.postdate = 226;
+   color.postname = 226;
+   color.posttext = 214;
+   color.postfrienddate = 226;
+   color.postfriendname = 226;
+   color.postfriendtext = 214;
+   color.anonymous = 226;
+   color.moreprompt = 220;
+   color.reserved4 = 16;
+   color.reserved5 = 16;
+   color.background = 16;
+   color.input1 = 220;
+   color.input2 = 231;
+   color.expresstext = 214;
+   color.expressname = 226;
+   color.expressfriendname = 226;
+   color.expressfriendtext = 214;
+}
+
 static void presetColorConfig( void )
 {
    stdPrintf( "Color presets\r\n\n" );
-   colorize( "@YD@Cefault  @YC@Colorblind  @YQ@Cuit@Y -> @G" );
+   colorize( "@YD@Cefault  @YC@Colorblind  @YH@Cotdog Stand  @YQ@Cuit@Y -> @G" );
 
    switch ( readValidatedMenuKey( COLOR_RESET_MENU_KEYS ) )
    {
@@ -294,6 +322,11 @@ static void presetColorConfig( void )
       case 'c':
          stdPrintf( "Colorblind\r\n" );
          colorblindColors();
+         break;
+
+      case 'h':
+         stdPrintf( "Hotdog Stand\r\n" );
+         hotDogColors();
          break;
 
       case 'q':

--- a/color_themes.c
+++ b/color_themes.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2024-2026 Stilgar
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "defs.h"
+#include "ext.h"
+
+/*
+ * defaultColors is called once with an arg of 1 before the bbsrc file is
+ * read.  This initializes all the color variables.  It is then called again
+ * after the bbsrc file is read, with an arg of 0.  This helps with reserved
+ * fields which might become used after a user upgrades to a later version
+ * which might use those reserved fields. They will get their default values
+ * instead of zero, which would render as black.
+ */
+#define ifzero( x ) if ( ( x ) < 0 || clearall )
+void defaultColors( int clearall )
+{
+   ifzero( color.text ) color.text = 2;
+   ifzero( color.forum ) color.forum = 3;
+   ifzero( color.number ) color.number = 6;
+   ifzero( color.errorTextColor ) color.errorTextColor = 1;
+   color.reserved1 = 0;
+   color.reserved2 = 0;
+   color.reserved3 = 0;
+   ifzero( color.postdate ) color.postdate = 5;
+   ifzero( color.postname ) color.postname = 6;
+   ifzero( color.posttext ) color.posttext = 2;
+   ifzero( color.postfrienddate ) color.postfrienddate = 5;
+   ifzero( color.postfriendname ) color.postfriendname = 1;
+   ifzero( color.postfriendtext ) color.postfriendtext = 2;
+   ifzero( color.anonymous ) color.anonymous = 3;
+   ifzero( color.moreprompt ) color.moreprompt = 3;
+   color.reserved4 = 0;
+   color.reserved5 = 0;
+   if ( clearall )
+   {
+      color.background = 0;
+   }
+   ifzero( color.input1 ) color.input1 = 2;
+   ifzero( color.input2 ) color.input2 = 6;
+   ifzero( color.expresstext ) color.expresstext = 2;
+   ifzero( color.expressname ) color.expressname = 2;
+   ifzero( color.expressfriendname ) color.expressfriendname = 2;
+   ifzero( color.expressfriendtext ) color.expressfriendtext = 2;
+}
+
+void colorblindColors( void )
+{
+   color.text = 231;
+   color.forum = 75;
+   color.number = 214;
+   color.errorTextColor = 166;
+   color.reserved1 = 16;
+   color.reserved2 = 16;
+   color.reserved3 = 16;
+   color.postdate = 75;
+   color.postname = 214;
+   color.posttext = 231;
+   color.postfrienddate = 25;
+   color.postfriendname = 175;
+   color.postfriendtext = 231;
+   color.anonymous = 221;
+   color.moreprompt = 221;
+   color.reserved4 = 16;
+   color.reserved5 = 16;
+   color.background = 16;
+   color.input1 = 231;
+   color.input2 = 36;
+   color.expresstext = 231;
+   color.expressname = 214;
+   color.expressfriendname = 175;
+   color.expressfriendtext = 231;
+}
+
+void hotDogColors( void )
+{
+   color.text = 220;
+   color.forum = 196;
+   color.number = 220;
+   color.errorTextColor = 231;
+   color.reserved1 = 16;
+   color.reserved2 = 16;
+   color.reserved3 = 16;
+   color.postdate = 226;
+   color.postname = 226;
+   color.posttext = 214;
+   color.postfrienddate = 226;
+   color.postfriendname = 226;
+   color.postfriendtext = 214;
+   color.anonymous = 226;
+   color.moreprompt = 220;
+   color.reserved4 = 16;
+   color.reserved5 = 16;
+   color.background = 16;
+   color.input1 = 220;
+   color.input2 = 231;
+   color.expresstext = 214;
+   color.expressname = 226;
+   color.expressfriendname = 226;
+   color.expressfriendtext = 214;
+}

--- a/config.c
+++ b/config.c
@@ -454,9 +454,10 @@ void newAwayMessage( void )
 
 void writeBbsRc( void )
 {
-   char aryColorBytes[40];
+   char aryColorBytes[COLOR_FIELD_COUNT + 1];
    int itemIndex, innerIndex;
    const friend *ptrFriend;
+   const int *ptrColorValues;
 
    deleteFile( aryBbsFriendsName );
    rewind( ptrBbsRc );
@@ -483,8 +484,12 @@ void writeBbsRc( void )
       fprintf( ptrBbsRc, "autopass %s\n", aryAutoPassword );
    }
 #endif
-   bcopy( (void *)&color, aryColorBytes, sizeof color );
-   aryColorBytes[sizeof color] = 0;
+   ptrColorValues = (const int *)&color;
+   for ( itemIndex = 0; itemIndex < COLOR_FIELD_COUNT; itemIndex++ )
+   {
+      aryColorBytes[itemIndex] = (char)colorValueToLegacyDigit( ptrColorValues[itemIndex] );
+   }
+   aryColorBytes[COLOR_FIELD_COUNT] = '\0';
    fprintf( ptrBbsRc, "color %s\n", aryColorBytes );
    if ( flagsConfiguration.shouldAutoAnswerAnsiPrompt )
    {

--- a/config.c
+++ b/config.c
@@ -454,8 +454,8 @@ void newAwayMessage( void )
 
 void writeBbsRc( void )
 {
-   char aryColorBytes[COLOR_FIELD_COUNT + 1];
    int itemIndex, innerIndex;
+   const char *ptrColorName;
    const friend *ptrFriend;
    const int *ptrColorValues;
 
@@ -485,12 +485,20 @@ void writeBbsRc( void )
    }
 #endif
    ptrColorValues = (const int *)&color;
+   fprintf( ptrBbsRc, "color" );
    for ( itemIndex = 0; itemIndex < COLOR_FIELD_COUNT; itemIndex++ )
    {
-      aryColorBytes[itemIndex] = (char)colorValueToLegacyDigit( ptrColorValues[itemIndex] );
+      ptrColorName = colorNameFromValue( ptrColorValues[itemIndex] );
+      if ( ptrColorName != NULL )
+      {
+         fprintf( ptrBbsRc, " %s", ptrColorName );
+      }
+      else
+      {
+         fprintf( ptrBbsRc, " %d", ptrColorValues[itemIndex] );
+      }
    }
-   aryColorBytes[COLOR_FIELD_COUNT] = '\0';
-   fprintf( ptrBbsRc, "color %s\n", aryColorBytes );
+   fprintf( ptrBbsRc, "\n" );
    if ( flagsConfiguration.shouldAutoAnswerAnsiPrompt )
    {
       fprintf( ptrBbsRc, "autoansi\n" );

--- a/defs.h
+++ b/defs.h
@@ -153,33 +153,34 @@ typedef struct
    time_t time;   /* Time online */
 } friend;         /* User list entry */
 
-/* The ordering of this struct is important. Do not change it. */
+#define COLOR_FIELD_COUNT 24
+
 typedef struct
 {
-   char text;           /* Plain text color */
-   char forum;          /* Forum prompt color */
-   char number;         /* Numbers and Read cmd prompt color */
-   char errorTextColor; /* Warning/error messages color */
-   char reserved1;
-   char reserved2;
-   char reserved3;
-   char postdate;       /* Post date stamp color */
-   char postname;       /* Post author name color */
-   char posttext;       /* Post text color */
-   char postfrienddate; /* Post friend date stamp color */
-   char postfriendname; /* Post friend name color */
-   char postfriendtext; /* Post friend text color */
-   char anonymous;      /* Anonymous post header color */
-   char moreprompt;     /* More prompt color */
-   char reserved4;
-   char reserved5;
-   char background;        /* Background color */
-   char input1;            /* Text input fields */
-   char input2;            /* Text input fields (highlight) */
-   char expresstext;       /* X message text color */
-   char expressname;       /* X message name color */
-   char expressfriendtext; /* X message from friend text color */
-   char expressfriendname; /* X message from friend name color*/
+   int text;           /* Plain text color */
+   int forum;          /* Forum prompt color */
+   int number;         /* Numbers and Read cmd prompt color */
+   int errorTextColor; /* Warning/error messages color */
+   int reserved1;
+   int reserved2;
+   int reserved3;
+   int postdate;       /* Post date stamp color */
+   int postname;       /* Post author name color */
+   int posttext;       /* Post text color */
+   int postfrienddate; /* Post friend date stamp color */
+   int postfriendname; /* Post friend name color */
+   int postfriendtext; /* Post friend text color */
+   int anonymous;      /* Anonymous post header color */
+   int moreprompt;     /* More prompt color */
+   int reserved4;
+   int reserved5;
+   int background;        /* Background color */
+   int input1;            /* Text input fields */
+   int input2;            /* Text input fields (highlight) */
+   int expresstext;       /* X message text color */
+   int expressname;       /* X message name color */
+   int expressfriendtext; /* X message from friend text color */
+   int expressfriendname; /* X message from friend name color*/
 } Color;
 
 #include "proto.h"

--- a/defs.h
+++ b/defs.h
@@ -72,6 +72,129 @@
 
 #include "sysio.h"
 
+static inline size_t appendAnsiColorSelector( char *ptrBuffer, size_t bufferSize,
+                                              size_t writeOffset, int colorValue,
+                                              bool isBackground )
+{
+   if ( writeOffset >= bufferSize )
+   {
+      return writeOffset;
+   }
+   if ( colorValue == 9 )
+   {
+      return writeOffset + (size_t)snprintf( ptrBuffer + writeOffset,
+                                             bufferSize - writeOffset,
+                                             "%d",
+                                             isBackground ? 49 : 39 );
+   }
+   if ( colorValue >= 0 && colorValue <= 7 )
+   {
+      return writeOffset + (size_t)snprintf( ptrBuffer + writeOffset,
+                                             bufferSize - writeOffset,
+                                             "%d",
+                                             ( isBackground ? 40 : 30 ) + colorValue );
+   }
+   if ( colorValue >= 8 && colorValue <= 15 )
+   {
+      return writeOffset + (size_t)snprintf( ptrBuffer + writeOffset,
+                                             bufferSize - writeOffset,
+                                             "%d",
+                                             ( isBackground ? 100 : 90 ) + ( colorValue - 8 ) );
+   }
+
+   return writeOffset + (size_t)snprintf( ptrBuffer + writeOffset,
+                                          bufferSize - writeOffset,
+                                          "%d;5;%d",
+                                          isBackground ? 48 : 38,
+                                          colorValue );
+}
+
+static inline int formatAnsiForegroundSequence( char *ptrBuffer, size_t bufferSize,
+                                                int colorValue )
+{
+   size_t safeOffset;
+   size_t writeOffset;
+
+   if ( bufferSize == 0 )
+   {
+      return 0;
+   }
+
+   writeOffset = (size_t)snprintf( ptrBuffer, bufferSize, "\033[" );
+   writeOffset = appendAnsiColorSelector( ptrBuffer, bufferSize, writeOffset,
+                                          colorValue, false );
+   safeOffset = writeOffset < bufferSize ? writeOffset : bufferSize - 1;
+   snprintf( ptrBuffer + safeOffset, writeOffset < bufferSize ? bufferSize - writeOffset : 0,
+             "m" );
+   return 1;
+}
+
+static inline int formatAnsiBackgroundSequence( char *ptrBuffer, size_t bufferSize,
+                                                int colorValue )
+{
+   size_t safeOffset;
+   size_t writeOffset;
+
+   if ( bufferSize == 0 )
+   {
+      return 0;
+   }
+
+   writeOffset = (size_t)snprintf( ptrBuffer, bufferSize, "\033[" );
+   writeOffset = appendAnsiColorSelector( ptrBuffer, bufferSize, writeOffset,
+                                          colorValue, true );
+   safeOffset = writeOffset < bufferSize ? writeOffset : bufferSize - 1;
+   snprintf( ptrBuffer + safeOffset, writeOffset < bufferSize ? bufferSize - writeOffset : 0,
+             "m" );
+   return 1;
+}
+
+static inline int formatAnsiDisplayStateSequence( char *ptrBuffer, size_t bufferSize,
+                                                  int foregroundColor,
+                                                  int backgroundColor,
+                                                  bool shouldUseBold )
+{
+   size_t safeOffset;
+   size_t writeOffset;
+
+   if ( bufferSize == 0 )
+   {
+      return 0;
+   }
+
+   writeOffset = (size_t)snprintf( ptrBuffer, bufferSize, "\033[%d;",
+                                   shouldUseBold ? 1 : 0 );
+   writeOffset = appendAnsiColorSelector( ptrBuffer, bufferSize, writeOffset,
+                                          foregroundColor, false );
+   if ( writeOffset < bufferSize )
+   {
+      writeOffset += (size_t)snprintf( ptrBuffer + writeOffset,
+                                       bufferSize - writeOffset,
+                                       ";" );
+   }
+   else
+   {
+      writeOffset++;
+   }
+   writeOffset = appendAnsiColorSelector( ptrBuffer, bufferSize, writeOffset,
+                                          backgroundColor, true );
+   safeOffset = writeOffset < bufferSize ? writeOffset : bufferSize - 1;
+   snprintf( ptrBuffer + safeOffset, writeOffset < bufferSize ? bufferSize - writeOffset : 0,
+             "m" );
+   return 1;
+}
+
+static inline int formatAnsiResetSequence( char *ptrBuffer, size_t bufferSize )
+{
+   if ( bufferSize == 0 )
+   {
+      return 0;
+   }
+
+   snprintf( ptrBuffer, bufferSize, "\033[0;39;49m" );
+   return 1;
+}
+
 typedef struct
 {
    char *start;   /* Pointer to beginning of queue */

--- a/defs.h
+++ b/defs.h
@@ -72,6 +72,8 @@
 
 #include "sysio.h"
 
+#define COLOR_VALUE_DEFAULT 256
+
 static inline size_t appendAnsiColorSelector( char *ptrBuffer, size_t bufferSize,
                                               size_t writeOffset, int colorValue,
                                               bool isBackground )
@@ -80,7 +82,7 @@ static inline size_t appendAnsiColorSelector( char *ptrBuffer, size_t bufferSize
    {
       return writeOffset;
    }
-   if ( colorValue == 9 )
+   if ( colorValue == COLOR_VALUE_DEFAULT )
    {
       return writeOffset + (size_t)snprintf( ptrBuffer + writeOffset,
                                              bufferSize - writeOffset,
@@ -277,6 +279,7 @@ typedef struct
 } friend;         /* User list entry */
 
 #define COLOR_FIELD_COUNT 24
+#define COLOR_BACKGROUND_INDEX 17
 
 typedef struct
 {

--- a/edit.c
+++ b/edit.c
@@ -559,7 +559,7 @@ int prompt( FILE *ptrMessageFile, int *previousChar, int commandChar )
                }
                if ( flagsConfiguration.useAnsi )
                {
-                  printf( "\033[%cm\033[3%cm", flagsConfiguration.useBold ? '1' : '0', lastColor );
+                  printf( "\033[%cm\033[3%dm", flagsConfiguration.useBold ? '1' : '0', lastColor );
                }
                printf( "[Editing complete]\r\n" );
                if ( !( tempFile = freopen( aryTempFileName, "r+", tempFile ) ) )

--- a/edit.c
+++ b/edit.c
@@ -559,7 +559,12 @@ int prompt( FILE *ptrMessageFile, int *previousChar, int commandChar )
                }
                if ( flagsConfiguration.useAnsi )
                {
-                  printf( "\033[%cm\033[3%dm", flagsConfiguration.useBold ? '1' : '0', lastColor );
+                  char aryAnsiSequence[32];
+
+                  formatAnsiDisplayStateSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                                  lastColor, color.background,
+                                                  flagsConfiguration.useBold );
+                  printf( "%s", aryAnsiSequence );
                }
                printf( "[Editing complete]\r\n" );
                if ( !( tempFile = freopen( aryTempFileName, "r+", tempFile ) ) )

--- a/ext.h
+++ b/ext.h
@@ -82,9 +82,9 @@ extern unsigned char aryPtyInputBuffer[1024]; /* buffer for input from pty */
 extern unsigned char *ptrPtyInput;            /* buffer pointer for input from pty */
 extern ssize_t ptyInputLength;                /* length of current input buffer from pty */
 
-extern int rows;       /* number of rows on aryUser's screen */
-extern int oldRows;    /* previous value of rows */
-extern char lastColor; /* last color code received from BBS */
+extern int rows;      /* number of rows on aryUser's screen */
+extern int oldRows;   /* previous value of rows */
+extern int lastColor; /* last color code received from BBS */
 
 extern long byte;                         /* current byte (remotely synched with bbs) */
 extern long targetByte;                   /* where the client wants to get */

--- a/filter.c
+++ b/filter.c
@@ -10,6 +10,40 @@
 
 static char thisline[320]; /* Copy of the current aryLine */
 
+static void printBufferedAnsiSequence( const char *ptrAnsiSequence, size_t sequenceLength )
+{
+   stdPrintf( "%.*s", (int)sequenceLength, ptrAnsiSequence );
+}
+
+static void emitTransformedAnsiSequence( const char *ptrAnsiSequence, size_t sequenceLength,
+                                         int isPostContext, int isFriend )
+{
+   if ( sequenceLength == 4 &&
+        memcmp( ptrAnsiSequence, "\033[1m", sequenceLength ) == 0 )
+   {
+      if ( flagsConfiguration.shouldDisableBold )
+      {
+         printBufferedAnsiSequence( ptrAnsiSequence, sequenceLength );
+         stdPrintf( "\033[0m" );
+         return;
+      }
+   }
+   if ( sequenceLength == 5 && ptrAnsiSequence[0] == '\033' &&
+        ptrAnsiSequence[1] == '[' && ptrAnsiSequence[2] == '3' &&
+        ptrAnsiSequence[4] == 'm' )
+   {
+      char aryAnsiSequence[32];
+
+      formatTransformedAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                               ptrAnsiSequence[3], isPostContext,
+                                               isFriend );
+      stdPrintf( "%s", aryAnsiSequence );
+      return;
+   }
+
+   printBufferedAnsiSequence( ptrAnsiSequence, sequenceLength );
+}
+
 void filterWhoList( register int inputChar )
 {
    static char new;
@@ -387,7 +421,8 @@ void filterPost( register int inputChar )
      */
    if ( !needs.prochdr )
    {
-      static int ansistate = 0; /* ANSI state count */
+      static char aryAnsiSequence[8];
+      static size_t ansiSequenceLength = 0;
 
       /* Store this aryLine for processing */
       if ( inputChar == '\n' )
@@ -410,26 +445,23 @@ void filterPost( register int inputChar )
       }
 
       /* Process ANSI codes in the middle of a post */
-      if ( ansistate )
+      if ( ansiSequenceLength > 0 )
       {
-         ansistate--;
-         if ( ansistate == 1 )
+         if ( ansiSequenceLength < sizeof( aryAnsiSequence ) )
          {
-            if ( flagsConfiguration.shouldDisableBold && inputChar == 109 )
-            { /* Turn boldface off */
-               printf( "m\033[0" );
-               ansistate--;
-            }
-            else
-            {
-               lastColor = ansiTransformPost( inputChar, isFriend );
-               inputChar = colorValueToLegacyDigit( lastColor );
-            }
+            aryAnsiSequence[ansiSequenceLength++] = (char)inputChar;
          }
+         if ( inputChar == 'm' || ansiSequenceLength >= sizeof( aryAnsiSequence ) )
+         {
+            emitTransformedAnsiSequence( aryAnsiSequence, ansiSequenceLength, 1, isFriend );
+            ansiSequenceLength = 0;
+         }
+         return;
       }
-      else if ( inputChar == '\033' )
+      if ( inputChar == '\033' )
       { /* Escape character */
-         ansistate = 4;
+         ansiSequenceLength = 0;
+         aryAnsiSequence[ansiSequenceLength++] = (char)inputChar;
          if ( !flagsConfiguration.useAnsi )
          {
             flagsConfiguration.useAnsi = 1;
@@ -438,16 +470,17 @@ void filterPost( register int inputChar )
                flagsConfiguration.shouldDisableBold = 1;
             }
          }
+         return;
       }
       /* Change color for end of more prompt */
       if ( flagsConfiguration.useAnsi && flagsConfiguration.isMorePromptActive && inputChar == ' ' )
       {
-         char aryAnsiSequence[32];
+         char aryMorePromptSequence[32];
 
          lastColor = color.text;
-         formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+         formatAnsiForegroundSequence( aryMorePromptSequence, sizeof( aryMorePromptSequence ),
                                        lastColor );
-         stdPrintf( "%s", aryAnsiSequence );
+         stdPrintf( "%s", aryMorePromptSequence );
       }
 
       /* Output character */
@@ -498,7 +531,7 @@ void filterPost( register int inputChar )
                       slistFind( friendList, ptrSenderName, fStrCompareVoid ) != -1 )
                        ? 1
                        : 0;
-         ansiTransformPostHeader( posthdr, isFriend );
+         ansiTransformPostHeader( posthdr, sizeof( posthdr ), isFriend );
          snprintf( arySavedHeader, sizeof( arySavedHeader ), "%s\r\n", posthdr );
          if ( needs.crlf )
          {
@@ -512,7 +545,8 @@ void filterPost( register int inputChar )
 
 void filterData( register int inputChar )
 {
-   static int ansistate = 0; /* Counter for ANSI transformations */
+   static char aryBufferedAnsiSequence[8];
+   static size_t bufferedAnsiSequenceLength = 0;
 
    /* Copy the current aryLine (or what we have so far) */
    if ( inputChar == '\n' )
@@ -582,31 +616,30 @@ void filterData( register int inputChar )
    }
 
    /* Parse ANSI sequences */
-   if ( ansistate )
+   if ( bufferedAnsiSequenceLength > 0 )
    {
-      ansistate--;
-      if ( ansistate == 1 )
+      if ( bufferedAnsiSequenceLength < sizeof( aryBufferedAnsiSequence ) )
       {
-         if ( flagsConfiguration.shouldDisableBold && inputChar == 109 )
-         { /* Turn boldface off */
-            stdPrintf( "m\033[0" );
-            ansistate--;
-         }
-         else
-         {
-            lastColor = ansiTransform( inputChar );
-            inputChar = colorValueToLegacyDigit( lastColor );
-         }
+         aryBufferedAnsiSequence[bufferedAnsiSequenceLength++] = (char)inputChar;
       }
+      if ( inputChar == 'm' || bufferedAnsiSequenceLength >= sizeof( aryBufferedAnsiSequence ) )
+      {
+         emitTransformedAnsiSequence( aryBufferedAnsiSequence,
+                                      bufferedAnsiSequenceLength,
+                                      0, 0 );
+         bufferedAnsiSequenceLength = 0;
+      }
+      return;
    }
-   else if ( inputChar == '\033' )
+   if ( inputChar == '\033' )
    { /* Escape character */
       char aryAnsiSequence[32];
 
       formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
                                     color.background );
       stdPrintf( "%s", aryAnsiSequence );
-      ansistate = 4;
+      bufferedAnsiSequenceLength = 0;
+      aryBufferedAnsiSequence[bufferedAnsiSequenceLength++] = (char)inputChar;
       if ( !flagsConfiguration.useAnsi )
       {
          flagsConfiguration.useAnsi = 1;
@@ -615,6 +648,7 @@ void filterData( register int inputChar )
             flagsConfiguration.shouldDisableBold = 1;
          }
       }
+      return;
    }
    if ( pendingLinesToEat > 0 )
    {

--- a/filter.c
+++ b/filter.c
@@ -422,8 +422,8 @@ void filterPost( register int inputChar )
             }
             else
             {
-               lastColor = ansiTransformPost( (char)inputChar, isFriend );
-               inputChar = lastColor;
+               lastColor = ansiTransformPost( inputChar, isFriend );
+               inputChar = colorValueToLegacyDigit( lastColor );
             }
          }
       }
@@ -442,7 +442,7 @@ void filterPost( register int inputChar )
       /* Change color for end of more prompt */
       if ( flagsConfiguration.useAnsi && flagsConfiguration.isMorePromptActive && inputChar == ' ' )
       {
-         stdPrintf( "\033[3%cm", lastColor = color.text ); /* assignment */
+         stdPrintf( "\033[3%dm", lastColor = color.text ); /* assignment */
       }
 
       /* Output character */
@@ -568,7 +568,7 @@ void filterData( register int inputChar )
    /* Change color for end of more prompt */
    if ( flagsConfiguration.useAnsi && flagsConfiguration.isMorePromptActive && inputChar == ' ' )
    {
-      stdPrintf( "\033[3%cm", lastColor = color.text ); /* assignment */
+      stdPrintf( "\033[3%dm", lastColor = color.text ); /* assignment */
    }
 
    /* Parse ANSI sequences */
@@ -584,14 +584,14 @@ void filterData( register int inputChar )
          }
          else
          {
-            lastColor = ansiTransform( (char)inputChar );
-            inputChar = lastColor;
+            lastColor = ansiTransform( inputChar );
+            inputChar = colorValueToLegacyDigit( lastColor );
          }
       }
    }
    else if ( inputChar == '\033' )
    { /* Escape character */
-      stdPrintf( "\033[4%cm", color.background );
+      stdPrintf( "\033[4%dm", color.background );
       ansistate = 4;
       if ( !flagsConfiguration.useAnsi )
       {

--- a/filter.c
+++ b/filter.c
@@ -442,7 +442,12 @@ void filterPost( register int inputChar )
       /* Change color for end of more prompt */
       if ( flagsConfiguration.useAnsi && flagsConfiguration.isMorePromptActive && inputChar == ' ' )
       {
-         stdPrintf( "\033[3%dm", lastColor = color.text ); /* assignment */
+         char aryAnsiSequence[32];
+
+         lastColor = color.text;
+         formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                       lastColor );
+         stdPrintf( "%s", aryAnsiSequence );
       }
 
       /* Output character */
@@ -568,7 +573,12 @@ void filterData( register int inputChar )
    /* Change color for end of more prompt */
    if ( flagsConfiguration.useAnsi && flagsConfiguration.isMorePromptActive && inputChar == ' ' )
    {
-      stdPrintf( "\033[3%dm", lastColor = color.text ); /* assignment */
+      char aryAnsiSequence[32];
+
+      lastColor = color.text;
+      formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                    lastColor );
+      stdPrintf( "%s", aryAnsiSequence );
    }
 
    /* Parse ANSI sequences */
@@ -591,7 +601,11 @@ void filterData( register int inputChar )
    }
    else if ( inputChar == '\033' )
    { /* Escape character */
-      stdPrintf( "\033[4%dm", color.background );
+      char aryAnsiSequence[32];
+
+      formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                    color.background );
+      stdPrintf( "%s", aryAnsiSequence );
       ansistate = 4;
       if ( !flagsConfiguration.useAnsi )
       {

--- a/getline.c
+++ b/getline.c
@@ -58,7 +58,11 @@ void getFiveLines( int which )
 #endif
    if ( flagsConfiguration.useAnsi )
    {
-      stdPrintf( "\033[3%dm", color.input1 );
+      char aryAnsiSequence[32];
+
+      formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                    color.input1 );
+      stdPrintf( "%s", aryAnsiSequence );
    }
    for ( lineIndex = 0; lineIndex < ( 20 + override + local ) && ( !lineIndex || *arySendString[lineIndex - 1] ); lineIndex++ )
    {
@@ -100,7 +104,12 @@ void getFiveLines( int which )
    }
    if ( flagsConfiguration.useAnsi )
    {
-      stdPrintf( "\033[3%dm", lastColor = color.text ); /* assignment */
+      char aryAnsiSequence[32];
+
+      lastColor = color.text;
+      formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                    lastColor );
+      stdPrintf( "%s", aryAnsiSequence );
    }
 }
 
@@ -171,13 +180,21 @@ void smartPrint( const char *ptrBuffer, const char *ptrEnd )
    }
    if ( flagsConfiguration.useAnsi )
    {
-      stdPrintf( "\033[3%dm", color.input1 );
+      char aryAnsiSequence[32];
+
+      formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                    color.input1 );
+      stdPrintf( "%s", aryAnsiSequence );
    }
    for ( ; *ptrScan != 0; ptrScan++ )
    {
       if ( ptrScan == ptrEnd && flagsConfiguration.useAnsi )
       {
-         stdPrintf( "\033[3%dm", color.input2 );
+         char aryAnsiSequence[32];
+
+         formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                       color.input2 );
+         stdPrintf( "%s", aryAnsiSequence );
       }
       putchar( *ptrScan );
    }
@@ -187,7 +204,11 @@ void smartPrint( const char *ptrBuffer, const char *ptrEnd )
    }
    if ( flagsConfiguration.useAnsi )
    {
-      stdPrintf( "\033[3%dm", color.input1 );
+      char aryAnsiSequence[32];
+
+      formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                    color.input1 );
+      stdPrintf( "%s", aryAnsiSequence );
    }
 }
 
@@ -228,7 +249,11 @@ char *getName( int quitPriv )
    lastPtr = 0;
    if ( flagsConfiguration.useAnsi )
    {
-      stdPrintf( "\033[3%dm", color.input1 );
+      char aryAnsiSequence[32];
+
+      formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                    color.input1 );
+      stdPrintf( "%s", aryAnsiSequence );
    }
    if ( quitPriv == 1 && *aryAutoName &&
         strcmp( aryAutoName, "NONE" ) && !isAutoLoggedIn )
@@ -250,7 +275,11 @@ char *getName( int quitPriv )
       }
       if ( flagsConfiguration.useAnsi )
       {
-         stdPrintf( "\033[3%dm", lastColor );
+         char aryAnsiSequence[32];
+
+         formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                       lastColor );
+         stdPrintf( "%s", aryAnsiSequence );
       }
       stdPrintf( "\rAutomatic reply to %s                     \r\n", junk );
       return ( junk );
@@ -438,7 +467,11 @@ char *getName( int quitPriv )
       {
          if ( flagsConfiguration.useAnsi )
          {
-            stdPrintf( "\033[3%dm", color.input1 );
+            char aryAnsiSequence[32];
+
+            formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                          color.input1 );
+            stdPrintf( "%s", aryAnsiSequence );
          }
          for ( ; *ptrCursor != 0; ptrCursor++ )
          {

--- a/getline.c
+++ b/getline.c
@@ -58,7 +58,7 @@ void getFiveLines( int which )
 #endif
    if ( flagsConfiguration.useAnsi )
    {
-      stdPrintf( "\033[3%cm", color.input1 );
+      stdPrintf( "\033[3%dm", color.input1 );
    }
    for ( lineIndex = 0; lineIndex < ( 20 + override + local ) && ( !lineIndex || *arySendString[lineIndex - 1] ); lineIndex++ )
    {
@@ -100,7 +100,7 @@ void getFiveLines( int which )
    }
    if ( flagsConfiguration.useAnsi )
    {
-      stdPrintf( "\033[3%cm", lastColor = color.text ); /* assignment */
+      stdPrintf( "\033[3%dm", lastColor = color.text ); /* assignment */
    }
 }
 
@@ -171,13 +171,13 @@ void smartPrint( const char *ptrBuffer, const char *ptrEnd )
    }
    if ( flagsConfiguration.useAnsi )
    {
-      stdPrintf( "\033[3%cm", color.input1 );
+      stdPrintf( "\033[3%dm", color.input1 );
    }
    for ( ; *ptrScan != 0; ptrScan++ )
    {
       if ( ptrScan == ptrEnd && flagsConfiguration.useAnsi )
       {
-         stdPrintf( "\033[3%cm", color.input2 );
+         stdPrintf( "\033[3%dm", color.input2 );
       }
       putchar( *ptrScan );
    }
@@ -187,7 +187,7 @@ void smartPrint( const char *ptrBuffer, const char *ptrEnd )
    }
    if ( flagsConfiguration.useAnsi )
    {
-      stdPrintf( "\033[3%cm", color.input1 );
+      stdPrintf( "\033[3%dm", color.input1 );
    }
 }
 
@@ -228,7 +228,7 @@ char *getName( int quitPriv )
    lastPtr = 0;
    if ( flagsConfiguration.useAnsi )
    {
-      stdPrintf( "\033[3%cm", color.input1 );
+      stdPrintf( "\033[3%dm", color.input1 );
    }
    if ( quitPriv == 1 && *aryAutoName &&
         strcmp( aryAutoName, "NONE" ) && !isAutoLoggedIn )
@@ -250,7 +250,7 @@ char *getName( int quitPriv )
       }
       if ( flagsConfiguration.useAnsi )
       {
-         stdPrintf( "\033[3%cm", lastColor );
+         stdPrintf( "\033[3%dm", lastColor );
       }
       stdPrintf( "\rAutomatic reply to %s                     \r\n", junk );
       return ( junk );
@@ -438,7 +438,7 @@ char *getName( int quitPriv )
       {
          if ( flagsConfiguration.useAnsi )
          {
-            stdPrintf( "\033[3%cm", color.input1 );
+            stdPrintf( "\033[3%dm", color.input1 );
          }
          for ( ; *ptrCursor != 0; ptrCursor++ )
          {

--- a/proto.h
+++ b/proto.h
@@ -109,13 +109,19 @@ extern void
    writeBbsRc P( (void));
 
 extern int
-   binarySearch P( (char *)),
+   ansiTransform P( (int)),
+   ansiTransformPost P( (int, int)),
+   backgroundPicker P( (void)),
    binarySort P( (void)),
+   binarySearch P( (char *)),
    capPrintf P( ( const char *, ... ) ),
    capPutChar P( (int)),
    capPuts P( (const char *)),
    checkFile P( (FILE *)),
    colorize P( (const char *)),
+   colorPicker P( (void)),
+   colorValueFromLegacyDigit P( (int)),
+   colorValueToLegacyDigit P( (int)),
    deleteQueue P( (queue *)),
    deleteFile P( (const char *)),
    extractNumber P( (const char *)),
@@ -158,10 +164,6 @@ extern int
    yesNoDefault P( (int));
 
 extern char
-   ansiTransform P( (char)),
-   ansiTransformPost P( (char, int)),
-   backgroundPicker P( (void)),
-   colorPicker P( (void)),
    expressColorMenu P( (void)),
    *extractName P( (const char *)),
    *extractNameNoHistory P( (const char *)),

--- a/proto.h
+++ b/proto.h
@@ -120,6 +120,7 @@ extern int
    checkFile P( (FILE *)),
    colorize P( (const char *)),
    colorPicker P( (void)),
+   colorValueFromName P( (const char *)),
    colorValueFromLegacyDigit P( (int)),
    colorValueToLegacyDigit P( (int)),
    deleteQueue P( (queue *)),
@@ -162,6 +163,9 @@ extern int
    waitNextEvent P( (void)),
    yesNo P( (void)),
    yesNoDefault P( (int));
+
+extern const char
+   *colorNameFromValue P( (int));
 
 extern char
    expressColorMenu P( (void)),

--- a/proto.h
+++ b/proto.h
@@ -23,6 +23,7 @@ extern void
    arguments P( (int, char **)),
    configBbsRc P( (void)),
    colorConfig P( (void)),
+   colorblindColors P( (void)),
    colorOptions P( (void)),
    connectBbs P( (void)),
    continuedDataHelper P( (void)),

--- a/proto.h
+++ b/proto.h
@@ -24,6 +24,7 @@ extern void
    configBbsRc P( (void)),
    colorConfig P( (void)),
    colorblindColors P( (void)),
+   hotDogColors P( (void)),
    colorOptions P( (void)),
    connectBbs P( (void)),
    continuedDataHelper P( (void)),

--- a/proto.h
+++ b/proto.h
@@ -19,7 +19,7 @@
 
 extern void
    ansiTransformExpress P( (char *, size_t)),
-   ansiTransformPostHeader P( (char *, int)),
+   ansiTransformPostHeader P( (char *, size_t, int)),
    arguments P( (int, char **)),
    configBbsRc P( (void)),
    colorConfig P( (void)),
@@ -123,6 +123,7 @@ extern int
    colorValueFromName P( (const char *)),
    colorValueFromLegacyDigit P( (int)),
    colorValueToLegacyDigit P( (int)),
+   formatTransformedAnsiForegroundSequence P( (char *, size_t, int, int, int)),
    deleteQueue P( (queue *)),
    deleteFile P( (const char *)),
    extractNumber P( (const char *)),

--- a/sysio.c
+++ b/sysio.c
@@ -42,7 +42,7 @@ int capPutChar( int inputChar )
          }
          else
          {
-            lastColor = (char)inputChar;
+            lastColor = colorValueFromLegacyDigit( inputChar );
          }
       }
    }

--- a/test/test_bbsrc.c
+++ b/test/test_bbsrc.c
@@ -97,6 +97,48 @@ int colorValueFromLegacyDigit( int inputChar )
    return inputChar;
 }
 
+int colorValueFromName( const char *ptrColorName )
+{
+   if ( strcmp( ptrColorName, "black" ) == 0 )
+   {
+      return 16;
+   }
+   if ( strcmp( ptrColorName, "red" ) == 0 )
+   {
+      return 160;
+   }
+   if ( strcmp( ptrColorName, "green" ) == 0 )
+   {
+      return 34;
+   }
+   if ( strcmp( ptrColorName, "yellow" ) == 0 )
+   {
+      return 220;
+   }
+   if ( strcmp( ptrColorName, "blue" ) == 0 )
+   {
+      return 26;
+   }
+   if ( strcmp( ptrColorName, "magenta" ) == 0 || strcmp( ptrColorName, "purple" ) == 0 )
+   {
+      return 91;
+   }
+   if ( strcmp( ptrColorName, "cyan" ) == 0 )
+   {
+      return 44;
+   }
+   if ( strcmp( ptrColorName, "white" ) == 0 )
+   {
+      return 231;
+   }
+   if ( strcmp( ptrColorName, "default" ) == 0 )
+   {
+      return 9;
+   }
+
+   return -1;
+}
+
 int fSortCompareVoid( const void *ptrLeft, const void *ptrRight )
 {
    const friend *const *ptrLeftFriend;
@@ -880,6 +922,70 @@ static void readBbsRc_WhenConfigContainsInvalidColor_PrintsWarning( void **state
    unlink( aryPath );
 }
 
+static void readBbsRc_WhenConfigUsesNamedColors_ParsesExtendedPaletteValues( void **state )
+{
+   // Arrange
+   char aryPath[PATH_MAX];
+
+   (void)state;
+
+   cleanupReadState();
+   resetTracking();
+   if ( !tryCreateTempPath( aryPath, sizeof( aryPath ), "/tmp/iobbsrc_test_XXXXXX" ) )
+   {
+      fail_msg( "Arrange failed: unable to create temporary path for named-color test" );
+      return;
+   }
+   if ( !tryWriteFileContents(
+           aryPath,
+           "color green yellow cyan red black black black magenta blue white red green yellow blue cyan black black default white green yellow magenta cyan purple\n"
+           "version 2310\n" ) )
+   {
+      unlink( aryPath );
+      fail_msg( "Arrange failed: unable to write named-color configuration content" );
+      return;
+   }
+   snprintf( aryBbsRcName, sizeof( aryBbsRcName ), "%s", aryPath );
+   snprintf( aryMyEditor, sizeof( aryMyEditor ), "%s", "nano" );
+   isLoginShell = 0;
+   isBbsRcReadOnly = 0;
+
+   // Act
+   readBbsRc();
+
+   // Assert
+   if ( color.text != 34 || color.forum != 220 || color.number != 44 || color.errorTextColor != 160 )
+   {
+      fail_msg( "named color parsing should set general colors to extended palette values; got text=%d forum=%d number=%d error=%d",
+                color.text, color.forum, color.number, color.errorTextColor );
+   }
+   if ( color.postdate != 91 || color.postname != 26 || color.posttext != 231 )
+   {
+      fail_msg( "named color parsing should set post colors; got date=%d name=%d text=%d",
+                color.postdate, color.postname, color.posttext );
+   }
+   if ( color.postfrienddate != 160 || color.postfriendname != 34 || color.postfriendtext != 220 )
+   {
+      fail_msg( "named color parsing should set friend post colors; got date=%d name=%d text=%d",
+                color.postfrienddate, color.postfriendname, color.postfriendtext );
+   }
+   if ( color.anonymous != 26 || color.moreprompt != 44 || color.background != 9 )
+   {
+      fail_msg( "named color parsing should set anonymous/more/background colors; got anonymous=%d more=%d background=%d",
+                color.anonymous, color.moreprompt, color.background );
+   }
+   if ( color.input1 != 231 || color.input2 != 34 || color.expresstext != 220 ||
+        color.expressname != 91 || color.expressfriendtext != 44 || color.expressfriendname != 91 )
+   {
+      fail_msg( "named color parsing should set input/express colors; got input1=%d input2=%d expresstext=%d expressname=%d expressfriendtext=%d expressfriendname=%d",
+                color.input1, color.input2, color.expresstext, color.expressname,
+                color.expressfriendtext, color.expressfriendname );
+   }
+
+   cleanupReadState();
+   unlink( aryPath );
+}
+
 static void readBbsRc_WhenConfigFileMissing_CreatesFileAndUsesDefaults( void **state )
 {
    // Arrange
@@ -937,6 +1043,7 @@ int main( void )
       cmocka_unit_test( readBbsRc_WhenConfigContainsMalformedKeepalive_PrintsWarningAndKeepsDefault ),
       cmocka_unit_test( readBbsRc_WhenConfigContainsInvalidDirective_PrintsSyntaxError ),
       cmocka_unit_test( readBbsRc_WhenConfigContainsInvalidColor_PrintsWarning ),
+      cmocka_unit_test( readBbsRc_WhenConfigUsesNamedColors_ParsesExtendedPaletteValues ),
       cmocka_unit_test( readBbsRc_WhenConfigFileMissing_CreatesFileAndUsesDefaults ),
    };
 

--- a/test/test_bbsrc.c
+++ b/test/test_bbsrc.c
@@ -986,6 +986,48 @@ static void readBbsRc_WhenConfigUsesNamedColors_ParsesExtendedPaletteValues( voi
    unlink( aryPath );
 }
 
+static void readBbsRc_WhenConfigUsesMixedNamedAndNumericColors_ParsesBothForms( void **state )
+{
+   // Arrange
+   char aryPath[PATH_MAX];
+
+   (void)state;
+
+   cleanupReadState();
+   resetTracking();
+   if ( !tryCreateTempPath( aryPath, sizeof( aryPath ), "/tmp/iobbsrc_test_XXXXXX" ) )
+   {
+      fail_msg( "Arrange failed: unable to create temporary path for mixed-color test" );
+      return;
+   }
+   if ( !tryWriteFileContents(
+           aryPath,
+           "color green 123 cyan red black black black magenta blue white red green yellow blue cyan black black default white green yellow magenta cyan purple\n"
+           "version 2310\n" ) )
+   {
+      unlink( aryPath );
+      fail_msg( "Arrange failed: unable to write mixed color configuration content" );
+      return;
+   }
+   snprintf( aryBbsRcName, sizeof( aryBbsRcName ), "%s", aryPath );
+   snprintf( aryMyEditor, sizeof( aryMyEditor ), "%s", "nano" );
+   isLoginShell = 0;
+   isBbsRcReadOnly = 0;
+
+   // Act
+   readBbsRc();
+
+   // Assert
+   if ( color.text != 34 || color.forum != 123 || color.number != 44 )
+   {
+      fail_msg( "mixed named/numeric parsing should preserve both forms; got text=%d forum=%d number=%d",
+                color.text, color.forum, color.number );
+   }
+
+   cleanupReadState();
+   unlink( aryPath );
+}
+
 static void readBbsRc_WhenConfigFileMissing_CreatesFileAndUsesDefaults( void **state )
 {
    // Arrange
@@ -1044,6 +1086,7 @@ int main( void )
       cmocka_unit_test( readBbsRc_WhenConfigContainsInvalidDirective_PrintsSyntaxError ),
       cmocka_unit_test( readBbsRc_WhenConfigContainsInvalidColor_PrintsWarning ),
       cmocka_unit_test( readBbsRc_WhenConfigUsesNamedColors_ParsesExtendedPaletteValues ),
+      cmocka_unit_test( readBbsRc_WhenConfigUsesMixedNamedAndNumericColors_ParsesBothForms ),
       cmocka_unit_test( readBbsRc_WhenConfigFileMissing_CreatesFileAndUsesDefaults ),
    };
 

--- a/test/test_bbsrc.c
+++ b/test/test_bbsrc.c
@@ -87,6 +87,16 @@ void defaultColors( int setall )
    (void)setall;
 }
 
+int colorValueFromLegacyDigit( int inputChar )
+{
+   if ( inputChar >= '0' && inputChar <= '9' )
+   {
+      return inputChar - '0';
+   }
+
+   return inputChar;
+}
+
 int fSortCompareVoid( const void *ptrLeft, const void *ptrRight )
 {
    const friend *const *ptrLeftFriend;

--- a/test/test_bbsrc.c
+++ b/test/test_bbsrc.c
@@ -99,6 +99,38 @@ int colorValueFromLegacyDigit( int inputChar )
 
 int colorValueFromName( const char *ptrColorName )
 {
+   if ( strcmp( ptrColorName, "brightblack" ) == 0 )
+   {
+      return 8;
+   }
+   if ( strcmp( ptrColorName, "brightred" ) == 0 )
+   {
+      return 9;
+   }
+   if ( strcmp( ptrColorName, "brightgreen" ) == 0 )
+   {
+      return 10;
+   }
+   if ( strcmp( ptrColorName, "brightyellow" ) == 0 )
+   {
+      return 11;
+   }
+   if ( strcmp( ptrColorName, "brightblue" ) == 0 )
+   {
+      return 12;
+   }
+   if ( strcmp( ptrColorName, "brightmagenta" ) == 0 || strcmp( ptrColorName, "brightpurple" ) == 0 )
+   {
+      return 13;
+   }
+   if ( strcmp( ptrColorName, "brightcyan" ) == 0 )
+   {
+      return 14;
+   }
+   if ( strcmp( ptrColorName, "brightwhite" ) == 0 )
+   {
+      return 15;
+   }
    if ( strcmp( ptrColorName, "black" ) == 0 )
    {
       return 16;
@@ -133,7 +165,7 @@ int colorValueFromName( const char *ptrColorName )
    }
    if ( strcmp( ptrColorName, "default" ) == 0 )
    {
-      return 9;
+      return COLOR_VALUE_DEFAULT;
    }
 
    return -1;
@@ -969,7 +1001,8 @@ static void readBbsRc_WhenConfigUsesNamedColors_ParsesExtendedPaletteValues( voi
       fail_msg( "named color parsing should set friend post colors; got date=%d name=%d text=%d",
                 color.postfrienddate, color.postfriendname, color.postfriendtext );
    }
-   if ( color.anonymous != 26 || color.moreprompt != 44 || color.background != 9 )
+   if ( color.anonymous != 26 || color.moreprompt != 44 ||
+        color.background != COLOR_VALUE_DEFAULT )
    {
       fail_msg( "named color parsing should set anonymous/more/background colors; got anonymous=%d more=%d background=%d",
                 color.anonymous, color.moreprompt, color.background );
@@ -980,6 +1013,53 @@ static void readBbsRc_WhenConfigUsesNamedColors_ParsesExtendedPaletteValues( voi
       fail_msg( "named color parsing should set input/express colors; got input1=%d input2=%d expresstext=%d expressname=%d expressfriendtext=%d expressfriendname=%d",
                 color.input1, color.input2, color.expresstext, color.expressname,
                 color.expressfriendtext, color.expressfriendname );
+   }
+
+   cleanupReadState();
+   unlink( aryPath );
+}
+
+static void readBbsRc_WhenConfigUsesBrightAnsiColorNames_ParsesAnsi16Values( void **state )
+{
+   // Arrange
+   char aryPath[PATH_MAX];
+
+   (void)state;
+
+   cleanupReadState();
+   resetTracking();
+   if ( !tryCreateTempPath( aryPath, sizeof( aryPath ), "/tmp/iobbsrc_test_XXXXXX" ) )
+   {
+      fail_msg( "Arrange failed: unable to create temporary path for bright ANSI color test" );
+      return;
+   }
+   if ( !tryWriteFileContents(
+           aryPath,
+           "color brightgreen brightyellow brightcyan brightred brightblack brightblack brightblack brightmagenta brightblue brightwhite brightred brightgreen brightyellow brightblue brightcyan brightblack brightblack default brightwhite brightgreen brightyellow brightmagenta brightcyan brightpurple\n"
+           "version 2310\n" ) )
+   {
+      unlink( aryPath );
+      fail_msg( "Arrange failed: unable to write bright ANSI color configuration content" );
+      return;
+   }
+   snprintf( aryBbsRcName, sizeof( aryBbsRcName ), "%s", aryPath );
+   snprintf( aryMyEditor, sizeof( aryMyEditor ), "%s", "nano" );
+   isLoginShell = 0;
+   isBbsRcReadOnly = 0;
+
+   // Act
+   readBbsRc();
+
+   // Assert
+   if ( color.text != 10 || color.forum != 11 || color.number != 14 || color.errorTextColor != 9 )
+   {
+      fail_msg( "bright ANSI color parsing should set general colors to ANSI 16 values; got text=%d forum=%d number=%d error=%d",
+                color.text, color.forum, color.number, color.errorTextColor );
+   }
+   if ( color.postdate != 13 || color.postname != 12 || color.posttext != 15 )
+   {
+      fail_msg( "bright ANSI color parsing should set post colors; got date=%d name=%d text=%d",
+                color.postdate, color.postname, color.posttext );
    }
 
    cleanupReadState();
@@ -1086,6 +1166,7 @@ int main( void )
       cmocka_unit_test( readBbsRc_WhenConfigContainsInvalidDirective_PrintsSyntaxError ),
       cmocka_unit_test( readBbsRc_WhenConfigContainsInvalidColor_PrintsWarning ),
       cmocka_unit_test( readBbsRc_WhenConfigUsesNamedColors_ParsesExtendedPaletteValues ),
+      cmocka_unit_test( readBbsRc_WhenConfigUsesBrightAnsiColorNames_ParsesAnsi16Values ),
       cmocka_unit_test( readBbsRc_WhenConfigUsesMixedNamedAndNumericColors_ParsesBothForms ),
       cmocka_unit_test( readBbsRc_WhenConfigFileMissing_CreatesFileAndUsesDefaults ),
    };

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -215,6 +215,102 @@ static void defaultColors_WhenClearAllDisabled_LeavesBackgroundUnchanged( void *
    }
 }
 
+static void colorValueFromName_WhenCanonicalNameProvided_ReturnsNamedPaletteValue( void **state )
+{
+   int colorValue;
+
+   // Arrange
+   (void)state;
+
+   resetState();
+
+   // Act
+   colorValue = colorValueFromName( "green" );
+
+   // Assert
+   if ( colorValue != 34 )
+   {
+      fail_msg( "colorValueFromName should map green to palette value 34; got %d", colorValue );
+   }
+}
+
+static void colorValueFromName_WhenAliasProvided_ReturnsCanonicalPaletteValue( void **state )
+{
+   int colorValue;
+
+   // Arrange
+   (void)state;
+
+   resetState();
+
+   // Act
+   colorValue = colorValueFromName( "Purple" );
+
+   // Assert
+   if ( colorValue != 91 )
+   {
+      fail_msg( "colorValueFromName should map Purple to palette value 91; got %d", colorValue );
+   }
+}
+
+static void colorValueFromName_WhenNameUnknown_ReturnsInvalidSentinel( void **state )
+{
+   int colorValue;
+
+   // Arrange
+   (void)state;
+
+   resetState();
+
+   // Act
+   colorValue = colorValueFromName( "chartreuse" );
+
+   // Assert
+   if ( colorValue != -1 )
+   {
+      fail_msg( "colorValueFromName should reject unknown names with -1; got %d", colorValue );
+   }
+}
+
+static void colorNameFromValue_WhenPaletteValueMatchesAlias_ReturnsCanonicalName( void **state )
+{
+   const char *ptrColorName;
+
+   // Arrange
+   (void)state;
+
+   resetState();
+
+   // Act
+   ptrColorName = colorNameFromValue( 91 );
+
+   // Assert
+   if ( ptrColorName == NULL || strcmp( ptrColorName, "magenta" ) != 0 )
+   {
+      fail_msg( "colorNameFromValue should return canonical name 'magenta' for value 91; got '%s'",
+                ptrColorName == NULL ? "(null)" : ptrColorName );
+   }
+}
+
+static void colorNameFromValue_WhenPaletteValueUnknown_ReturnsNull( void **state )
+{
+   const char *ptrColorName;
+
+   // Arrange
+   (void)state;
+
+   resetState();
+
+   // Act
+   ptrColorName = colorNameFromValue( 999 );
+
+   // Assert
+   if ( ptrColorName != NULL )
+   {
+      fail_msg( "colorNameFromValue should return NULL for unknown values; got '%s'", ptrColorName );
+   }
+}
+
 static void ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes( void **state )
 {
    // Arrange
@@ -359,6 +455,11 @@ int main( void )
    const struct CMUnitTest aryTests[] = {
       cmocka_unit_test( defaultColors_WhenClearAllApplied_SetsKnownDefaults ),
       cmocka_unit_test( defaultColors_WhenClearAllDisabled_LeavesBackgroundUnchanged ),
+      cmocka_unit_test( colorValueFromName_WhenCanonicalNameProvided_ReturnsNamedPaletteValue ),
+      cmocka_unit_test( colorValueFromName_WhenAliasProvided_ReturnsCanonicalPaletteValue ),
+      cmocka_unit_test( colorValueFromName_WhenNameUnknown_ReturnsInvalidSentinel ),
+      cmocka_unit_test( colorNameFromValue_WhenPaletteValueMatchesAlias_ReturnsCanonicalName ),
+      cmocka_unit_test( colorNameFromValue_WhenPaletteValueUnknown_ReturnsNull ),
       cmocka_unit_test( ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes ),
       cmocka_unit_test( ansiTransformExpress_WhenAnsiDisabled_LeavesTextUnchanged ),
       cmocka_unit_test( ansiTransformPostHeader_WhenFriendPost_RewritesHeaderDigitsAndTracksColor ),

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -494,20 +494,20 @@ static void ansiTransformPostHeader_WhenFriendPost_RewritesHeaderDigitsAndTracks
 
    resetState();
    color.postfrienddate = 4;
-   color.postfriendname = 5;
+   color.postfriendname = 13;
    color.postfriendtext = 2;
    snprintf( aryHeader, sizeof( aryHeader ), "%s",
              "\033[35mMar 1, 2026 3:34 PM\033[32m from \033[36mSkankhunt Four Two\033[32m" );
 
    // Act
-   ansiTransformPostHeader( aryHeader, 1 );
+   ansiTransformPostHeader( aryHeader, sizeof( aryHeader ), 1 );
 
    // Assert
    if ( strstr( aryHeader, "\033[34mMar 1, 2026 3:34 PM" ) == NULL )
    {
       fail_msg( "ansiTransformPostHeader should remap friend post date color; got '%s'", aryHeader );
    }
-   if ( strstr( aryHeader, "\033[35mSkankhunt Four Two" ) == NULL )
+   if ( strstr( aryHeader, "\033[95mSkankhunt Four Two" ) == NULL )
    {
       fail_msg( "ansiTransformPostHeader should remap friend post name color; got '%s'", aryHeader );
    }
@@ -543,6 +543,27 @@ static void colorPicker_WhenInvalidThenValidInput_ReturnsMappedColorAndFlushes( 
    }
 }
 
+static void colorPicker_WhenBrightAnsiDigitSelected_ReturnsBrightAnsiValue( void **state )
+{
+   // Arrange
+   const int aryKeys[] = { '6' };
+   int result;
+
+   (void)state;
+
+   resetState();
+   setInputSequence( aryKeys, sizeof( aryKeys ) / sizeof( aryKeys[0] ) );
+
+   // Act
+   result = colorPicker();
+
+   // Assert
+   if ( result != 13 )
+   {
+      fail_msg( "colorPicker should map '6' to bright magenta value 13; got %d", result );
+   }
+}
+
 static void backgroundPicker_WhenDefaultSelected_ReturnsDefaultCode( void **state )
 {
    // Arrange
@@ -570,6 +591,28 @@ static void backgroundPicker_WhenDefaultSelected_ReturnsDefaultCode( void **stat
    }
 }
 
+static void backgroundPicker_WhenBrightAnsiDigitSelected_ReturnsBrightAnsiValue( void **state )
+{
+   // Arrange
+   const int aryKeys[] = { '8' };
+   int result;
+
+   (void)state;
+
+   resetState();
+   color.background = 2;
+   setInputSequence( aryKeys, sizeof( aryKeys ) / sizeof( aryKeys[0] ) );
+
+   // Act
+   result = backgroundPicker();
+
+   // Assert
+   if ( result != 15 )
+   {
+      fail_msg( "backgroundPicker should map '8' to bright white value 15; got %d", result );
+   }
+}
+
 int main( void )
 {
    const struct CMUnitTest aryTests[] = {
@@ -590,7 +633,9 @@ int main( void )
       cmocka_unit_test( ansiTransformExpress_WhenAnsiDisabled_LeavesTextUnchanged ),
       cmocka_unit_test( ansiTransformPostHeader_WhenFriendPost_RewritesHeaderDigitsAndTracksColor ),
       cmocka_unit_test( colorPicker_WhenInvalidThenValidInput_ReturnsMappedColorAndFlushes ),
+      cmocka_unit_test( colorPicker_WhenBrightAnsiDigitSelected_ReturnsBrightAnsiValue ),
       cmocka_unit_test( backgroundPicker_WhenDefaultSelected_ReturnsDefaultCode ),
+      cmocka_unit_test( backgroundPicker_WhenBrightAnsiDigitSelected_ReturnsBrightAnsiValue ),
    };
 
    return cmocka_run_group_tests( aryTests, NULL, NULL );

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -431,6 +431,40 @@ static void formatAnsiDisplayStateSequence_WhenDefaultBackgroundRequested_UsesCo
    }
 }
 
+static void colorblindColors_WhenApplied_SetsAccessiblePalette( void **state )
+{
+   // Arrange
+   (void)state;
+
+   resetState();
+   memset( &color, 0, sizeof( color ) );
+
+   // Act
+   colorblindColors();
+
+   // Assert
+   if ( color.text != 231 || color.forum != 75 || color.number != 214 ||
+        color.errorTextColor != 166 )
+   {
+      fail_msg( "colorblindColors should set general accessible colors; got text=%d forum=%d number=%d error=%d",
+                color.text, color.forum, color.number, color.errorTextColor );
+   }
+   if ( color.background != 16 )
+   {
+      fail_msg( "colorblindColors should keep a dark background; got %d", color.background );
+   }
+   if ( color.postdate != 75 || color.postfrienddate != 25 ||
+        color.postname != 214 || color.postfriendname != 175 ||
+        color.input2 != 36 || color.moreprompt != 221 ||
+        color.expressname != 214 || color.expressfriendname != 175 )
+   {
+      fail_msg( "colorblindColors should map post, input, and express roles onto the preset palette; got postdate=%d frienddate=%d postname=%d friendname=%d input2=%d moreprompt=%d expressname=%d expressfriendname=%d",
+                color.postdate, color.postfrienddate, color.postname,
+                color.postfriendname, color.input2, color.moreprompt,
+                color.expressname, color.expressfriendname );
+   }
+}
+
 static void ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes( void **state )
 {
    // Arrange
@@ -629,6 +663,7 @@ int main( void )
       cmocka_unit_test( formatAnsiForegroundSequence_WhenBrightColorRequested_UsesBrightAnsiCode ),
       cmocka_unit_test( formatAnsiForegroundSequence_WhenExtendedColorRequested_Uses256ColorCode ),
       cmocka_unit_test( formatAnsiDisplayStateSequence_WhenDefaultBackgroundRequested_UsesCombinedSelectors ),
+      cmocka_unit_test( colorblindColors_WhenApplied_SetsAccessiblePalette ),
       cmocka_unit_test( ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes ),
       cmocka_unit_test( ansiTransformExpress_WhenAnsiDisabled_LeavesTextUnchanged ),
       cmocka_unit_test( ansiTransformPostHeader_WhenFriendPost_RewritesHeaderDigitsAndTracksColor ),

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -253,6 +253,25 @@ static void colorValueFromName_WhenAliasProvided_ReturnsCanonicalPaletteValue( v
    }
 }
 
+static void colorValueFromName_WhenBrightAnsiNameProvided_ReturnsBrightAnsiValue( void **state )
+{
+   int colorValue;
+
+   // Arrange
+   (void)state;
+
+   resetState();
+
+   // Act
+   colorValue = colorValueFromName( "BrightBlue" );
+
+   // Assert
+   if ( colorValue != 12 )
+   {
+      fail_msg( "colorValueFromName should map BrightBlue to ANSI 16 value 12; got %d", colorValue );
+   }
+}
+
 static void colorValueFromName_WhenNameUnknown_ReturnsInvalidSentinel( void **state )
 {
    int colorValue;
@@ -288,6 +307,26 @@ static void colorNameFromValue_WhenPaletteValueMatchesAlias_ReturnsCanonicalName
    if ( ptrColorName == NULL || strcmp( ptrColorName, "magenta" ) != 0 )
    {
       fail_msg( "colorNameFromValue should return canonical name 'magenta' for value 91; got '%s'",
+                ptrColorName == NULL ? "(null)" : ptrColorName );
+   }
+}
+
+static void colorNameFromValue_WhenBrightAnsiValueProvided_ReturnsBrightCanonicalName( void **state )
+{
+   const char *ptrColorName;
+
+   // Arrange
+   (void)state;
+
+   resetState();
+
+   // Act
+   ptrColorName = colorNameFromValue( 13 );
+
+   // Assert
+   if ( ptrColorName == NULL || strcmp( ptrColorName, "brightmagenta" ) != 0 )
+   {
+      fail_msg( "colorNameFromValue should return canonical name 'brightmagenta' for value 13; got '%s'",
                 ptrColorName == NULL ? "(null)" : ptrColorName );
    }
 }
@@ -381,7 +420,8 @@ static void formatAnsiDisplayStateSequence_WhenDefaultBackgroundRequested_UsesCo
    resetState();
 
    // Act
-   formatAnsiDisplayStateSequence( arySequence, sizeof( arySequence ), 7, 9, false );
+   formatAnsiDisplayStateSequence( arySequence, sizeof( arySequence ), 7,
+                                   COLOR_VALUE_DEFAULT, false );
 
    // Assert
    if ( strcmp( arySequence, "\033[0;37;49m" ) != 0 )
@@ -519,9 +559,9 @@ static void backgroundPicker_WhenDefaultSelected_ReturnsDefaultCode( void **stat
    result = backgroundPicker();
 
    // Assert
-   if ( result != 9 )
+   if ( result != COLOR_VALUE_DEFAULT )
    {
-      fail_msg( "backgroundPicker should map 'D' to default code 9; got %d", result );
+      fail_msg( "backgroundPicker should map 'D' to the default color sentinel; got %d", result );
    }
    if ( flushCount != 1 || lastFlushValue != 2 )
    {
@@ -537,8 +577,10 @@ int main( void )
       cmocka_unit_test( defaultColors_WhenClearAllDisabled_LeavesBackgroundUnchanged ),
       cmocka_unit_test( colorValueFromName_WhenCanonicalNameProvided_ReturnsNamedPaletteValue ),
       cmocka_unit_test( colorValueFromName_WhenAliasProvided_ReturnsCanonicalPaletteValue ),
+      cmocka_unit_test( colorValueFromName_WhenBrightAnsiNameProvided_ReturnsBrightAnsiValue ),
       cmocka_unit_test( colorValueFromName_WhenNameUnknown_ReturnsInvalidSentinel ),
       cmocka_unit_test( colorNameFromValue_WhenPaletteValueMatchesAlias_ReturnsCanonicalName ),
+      cmocka_unit_test( colorNameFromValue_WhenBrightAnsiValueProvided_ReturnsBrightCanonicalName ),
       cmocka_unit_test( colorNameFromValue_WhenPaletteValueUnknown_ReturnsNull ),
       cmocka_unit_test( formatAnsiForegroundSequence_WhenClassicColorRequested_UsesClassicAnsiCode ),
       cmocka_unit_test( formatAnsiForegroundSequence_WhenBrightColorRequested_UsesBrightAnsiCode ),

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -198,7 +198,7 @@ static void defaultColors_WhenClearAllDisabled_LeavesBackgroundUnchanged( void *
 
    resetState();
    memset( &color, 0, sizeof( color ) );
-   color.text = 9;
+   color.text = -1;
    color.background = 4;
 
    // Act
@@ -207,7 +207,7 @@ static void defaultColors_WhenClearAllDisabled_LeavesBackgroundUnchanged( void *
    // Assert
    if ( color.text != 2 )
    {
-      fail_msg( "defaultColors(0) should repair invalid text color to default 2; got %d", color.text );
+      fail_msg( "defaultColors(0) should repair negative text color to default 2; got %d", color.text );
    }
    if ( color.background != 4 )
    {

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -311,6 +311,86 @@ static void colorNameFromValue_WhenPaletteValueUnknown_ReturnsNull( void **state
    }
 }
 
+static void formatAnsiForegroundSequence_WhenClassicColorRequested_UsesClassicAnsiCode( void **state )
+{
+   char arySequence[32];
+
+   // Arrange
+   (void)state;
+
+   resetState();
+
+   // Act
+   formatAnsiForegroundSequence( arySequence, sizeof( arySequence ), 2 );
+
+   // Assert
+   if ( strcmp( arySequence, "\033[32m" ) != 0 )
+   {
+      fail_msg( "formatAnsiForegroundSequence should encode classic green as '\\033[32m'; got '%s'",
+                arySequence );
+   }
+}
+
+static void formatAnsiForegroundSequence_WhenBrightColorRequested_UsesBrightAnsiCode( void **state )
+{
+   char arySequence[32];
+
+   // Arrange
+   (void)state;
+
+   resetState();
+
+   // Act
+   formatAnsiForegroundSequence( arySequence, sizeof( arySequence ), 10 );
+
+   // Assert
+   if ( strcmp( arySequence, "\033[92m" ) != 0 )
+   {
+      fail_msg( "formatAnsiForegroundSequence should encode bright green as '\\033[92m'; got '%s'",
+                arySequence );
+   }
+}
+
+static void formatAnsiForegroundSequence_WhenExtendedColorRequested_Uses256ColorCode( void **state )
+{
+   char arySequence[32];
+
+   // Arrange
+   (void)state;
+
+   resetState();
+
+   // Act
+   formatAnsiForegroundSequence( arySequence, sizeof( arySequence ), 34 );
+
+   // Assert
+   if ( strcmp( arySequence, "\033[38;5;34m" ) != 0 )
+   {
+      fail_msg( "formatAnsiForegroundSequence should encode extended palette value 34 as '\\033[38;5;34m'; got '%s'",
+                arySequence );
+   }
+}
+
+static void formatAnsiDisplayStateSequence_WhenDefaultBackgroundRequested_UsesCombinedSelectors( void **state )
+{
+   char arySequence[32];
+
+   // Arrange
+   (void)state;
+
+   resetState();
+
+   // Act
+   formatAnsiDisplayStateSequence( arySequence, sizeof( arySequence ), 7, 9, false );
+
+   // Assert
+   if ( strcmp( arySequence, "\033[0;37;49m" ) != 0 )
+   {
+      fail_msg( "formatAnsiDisplayStateSequence should encode white-on-default without bold as '\\033[0;37;49m'; got '%s'",
+                arySequence );
+   }
+}
+
 static void ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes( void **state )
 {
    // Arrange
@@ -460,6 +540,10 @@ int main( void )
       cmocka_unit_test( colorValueFromName_WhenNameUnknown_ReturnsInvalidSentinel ),
       cmocka_unit_test( colorNameFromValue_WhenPaletteValueMatchesAlias_ReturnsCanonicalName ),
       cmocka_unit_test( colorNameFromValue_WhenPaletteValueUnknown_ReturnsNull ),
+      cmocka_unit_test( formatAnsiForegroundSequence_WhenClassicColorRequested_UsesClassicAnsiCode ),
+      cmocka_unit_test( formatAnsiForegroundSequence_WhenBrightColorRequested_UsesBrightAnsiCode ),
+      cmocka_unit_test( formatAnsiForegroundSequence_WhenExtendedColorRequested_Uses256ColorCode ),
+      cmocka_unit_test( formatAnsiDisplayStateSequence_WhenDefaultBackgroundRequested_UsesCombinedSelectors ),
       cmocka_unit_test( ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes ),
       cmocka_unit_test( ansiTransformExpress_WhenAnsiDisabled_LeavesTextUnchanged ),
       cmocka_unit_test( ansiTransformPostHeader_WhenFriendPost_RewritesHeaderDigitsAndTracksColor ),

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -465,6 +465,49 @@ static void colorblindColors_WhenApplied_SetsAccessiblePalette( void **state )
    }
 }
 
+static void hotDogColors_WhenApplied_SetsClassicHotDogPalette( void **state )
+{
+   // Arrange
+   (void)state;
+
+   resetState();
+   memset( &color, 0, sizeof( color ) );
+
+   // Act
+   hotDogColors();
+
+   // Assert
+   if ( color.text != 220 || color.forum != 196 || color.number != 220 ||
+        color.errorTextColor != 231 )
+   {
+      fail_msg( "hotDogColors should set general hot dog colors; got text=%d forum=%d number=%d error=%d",
+                color.text, color.forum, color.number, color.errorTextColor );
+   }
+   if ( color.background != 16 )
+   {
+      fail_msg( "hotDogColors should keep a black background; got %d", color.background );
+   }
+   if ( color.posttext != 214 || color.postfriendtext != 214 ||
+        color.expresstext != 214 || color.expressfriendtext != 214 )
+   {
+      fail_msg( "hotDogColors should keep only post and eXpress bodies orange; got posttext=%d friendposttext=%d expresstext=%d friendexpresstext=%d",
+                color.posttext, color.postfriendtext, color.expresstext,
+                color.expressfriendtext );
+   }
+
+   if ( color.postdate != 226 || color.postfrienddate != 226 ||
+        color.postname != 226 || color.postfriendname != 226 ||
+        color.anonymous != 226 || color.moreprompt != 220 ||
+        color.input1 != 220 || color.expressname != 226 ||
+        color.expressfriendname != 226 )
+   {
+      fail_msg( "hotDogColors should keep date and name headers yellow while leaving only bodies orange; got postdate=%d frienddate=%d postname=%d friendname=%d anonymous=%d moreprompt=%d input1=%d expressname=%d expressfriendname=%d",
+                color.postdate, color.postfrienddate, color.postname,
+                color.postfriendname, color.anonymous, color.moreprompt,
+                color.input1, color.expressname, color.expressfriendname );
+   }
+}
+
 static void ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes( void **state )
 {
    // Arrange
@@ -664,6 +707,7 @@ int main( void )
       cmocka_unit_test( formatAnsiForegroundSequence_WhenExtendedColorRequested_Uses256ColorCode ),
       cmocka_unit_test( formatAnsiDisplayStateSequence_WhenDefaultBackgroundRequested_UsesCombinedSelectors ),
       cmocka_unit_test( colorblindColors_WhenApplied_SetsAccessiblePalette ),
+      cmocka_unit_test( hotDogColors_WhenApplied_SetsClassicHotDogPalette ),
       cmocka_unit_test( ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes ),
       cmocka_unit_test( ansiTransformExpress_WhenAnsiDisabled_LeavesTextUnchanged ),
       cmocka_unit_test( ansiTransformPostHeader_WhenFriendPost_RewritesHeaderDigitsAndTracksColor ),

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -27,7 +27,7 @@ static void resetState( void )
    lastFlushValue = 0;
 
    flagsConfiguration.useAnsi = 0;
-   lastColor = '0';
+   lastColor = 0;
 
    if ( friendList != NULL )
    {
@@ -170,22 +170,22 @@ static void defaultColors_WhenClearAllApplied_SetsKnownDefaults( void **state )
    (void)state;
 
    resetState();
-   memset( &color, '0', sizeof( color ) );
-   color.background = '7';
+   memset( &color, 0, sizeof( color ) );
+   color.background = 7;
 
    // Act
    defaultColors( 1 );
 
    // Assert
-   if ( color.text != '2' || color.forum != '3' || color.number != '6' || color.errorTextColor != '1' )
+   if ( color.text != 2 || color.forum != 3 || color.number != 6 || color.errorTextColor != 1 )
    {
       fail_msg( "defaultColors(1) did not set general default colors as expected" );
    }
-   if ( color.background != '0' )
+   if ( color.background != 0 )
    {
-      fail_msg( "defaultColors(1) should reset background to '0'; got '%c'", color.background );
+      fail_msg( "defaultColors(1) should reset background to 0; got %d", color.background );
    }
-   if ( color.postname != '6' || color.postfriendname != '1' || color.expressname != '2' )
+   if ( color.postname != 6 || color.postfriendname != 1 || color.expressname != 2 )
    {
       fail_msg( "defaultColors(1) did not set post/express defaults as expected" );
    }
@@ -197,21 +197,21 @@ static void defaultColors_WhenClearAllDisabled_LeavesBackgroundUnchanged( void *
    (void)state;
 
    resetState();
-   memset( &color, '0', sizeof( color ) );
-   color.text = '9';
-   color.background = '4';
+   memset( &color, 0, sizeof( color ) );
+   color.text = 9;
+   color.background = 4;
 
    // Act
    defaultColors( 0 );
 
    // Assert
-   if ( color.text != '2' )
+   if ( color.text != 2 )
    {
-      fail_msg( "defaultColors(0) should repair invalid text color to default '2'; got '%c'", color.text );
+      fail_msg( "defaultColors(0) should repair invalid text color to default 2; got %d", color.text );
    }
-   if ( color.background != '4' )
+   if ( color.background != 4 )
    {
-      fail_msg( "defaultColors(0) should not overwrite existing background; got '%c'", color.background );
+      fail_msg( "defaultColors(0) should not overwrite existing background; got %d", color.background );
    }
 }
 
@@ -224,11 +224,11 @@ static void ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes( void **s
 
    resetState();
    flagsConfiguration.useAnsi = 1;
-   color.expressfriendtext = '3';
-   color.expressfriendname = '5';
-   color.text = '7';
-   color.expresstext = '2';
-   color.expressname = '6';
+   color.expressfriendtext = 3;
+   color.expressfriendname = 5;
+   color.text = 7;
+   color.expresstext = 2;
+   color.expressname = 6;
    addFriend( "Dr Strange" );
    snprintf( aryMessage, sizeof( aryMessage ), "%s", "*** Message (#1) from Dr Strange at 11:01 ***" );
 
@@ -242,7 +242,7 @@ static void ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes( void **s
    }
    if ( lastColor != color.text )
    {
-      fail_msg( "ansiTransformExpress should set lastColor to text color; got '%c'", lastColor );
+      fail_msg( "ansiTransformExpress should set lastColor to text color; got %d", lastColor );
    }
 }
 
@@ -269,11 +269,43 @@ static void ansiTransformExpress_WhenAnsiDisabled_LeavesTextUnchanged( void **st
    }
 }
 
+static void ansiTransformPostHeader_WhenFriendPost_RewritesHeaderDigitsAndTracksColor( void **state )
+{
+   // Arrange
+   char aryHeader[256];
+
+   (void)state;
+
+   resetState();
+   color.postfrienddate = 4;
+   color.postfriendname = 5;
+   color.postfriendtext = 2;
+   snprintf( aryHeader, sizeof( aryHeader ), "%s",
+             "\033[35mMar 1, 2026 3:34 PM\033[32m from \033[36mSkankhunt Four Two\033[32m" );
+
+   // Act
+   ansiTransformPostHeader( aryHeader, 1 );
+
+   // Assert
+   if ( strstr( aryHeader, "\033[34mMar 1, 2026 3:34 PM" ) == NULL )
+   {
+      fail_msg( "ansiTransformPostHeader should remap friend post date color; got '%s'", aryHeader );
+   }
+   if ( strstr( aryHeader, "\033[35mSkankhunt Four Two" ) == NULL )
+   {
+      fail_msg( "ansiTransformPostHeader should remap friend post name color; got '%s'", aryHeader );
+   }
+   if ( lastColor != color.postfriendtext )
+   {
+      fail_msg( "ansiTransformPostHeader should set lastColor to friend post text color; got %d", lastColor );
+   }
+}
+
 static void colorPicker_WhenInvalidThenValidInput_ReturnsMappedColorAndFlushes( void **state )
 {
    // Arrange
    const int aryKeys[] = { 'z', 'x', 'R' };
-   char result;
+   int result;
 
    (void)state;
 
@@ -284,9 +316,9 @@ static void colorPicker_WhenInvalidThenValidInput_ReturnsMappedColorAndFlushes( 
    result = colorPicker();
 
    // Assert
-   if ( result != '1' )
+   if ( result != 1 )
    {
-      fail_msg( "colorPicker should map 'R' to color code '1'; got '%c'", result );
+      fail_msg( "colorPicker should map 'R' to color code 1; got %d", result );
    }
    if ( flushCount != 1 || lastFlushValue != 2 )
    {
@@ -299,21 +331,21 @@ static void backgroundPicker_WhenDefaultSelected_ReturnsDefaultCode( void **stat
 {
    // Arrange
    const int aryKeys[] = { 'x', 'x', 'D' };
-   char result;
+   int result;
 
    (void)state;
 
    resetState();
-   color.background = '2';
+   color.background = 2;
    setInputSequence( aryKeys, sizeof( aryKeys ) / sizeof( aryKeys[0] ) );
 
    // Act
    result = backgroundPicker();
 
    // Assert
-   if ( result != '9' )
+   if ( result != 9 )
    {
-      fail_msg( "backgroundPicker should map 'D' to default code '9'; got '%c'", result );
+      fail_msg( "backgroundPicker should map 'D' to default code 9; got %d", result );
    }
    if ( flushCount != 1 || lastFlushValue != 2 )
    {
@@ -329,6 +361,7 @@ int main( void )
       cmocka_unit_test( defaultColors_WhenClearAllDisabled_LeavesBackgroundUnchanged ),
       cmocka_unit_test( ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes ),
       cmocka_unit_test( ansiTransformExpress_WhenAnsiDisabled_LeavesTextUnchanged ),
+      cmocka_unit_test( ansiTransformPostHeader_WhenFriendPost_RewritesHeaderDigitsAndTracksColor ),
       cmocka_unit_test( colorPicker_WhenInvalidThenValidInput_ReturnsMappedColorAndFlushes ),
       cmocka_unit_test( backgroundPicker_WhenDefaultSelected_ReturnsDefaultCode ),
    };

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -109,6 +109,33 @@ int colorValueToLegacyDigit( int colorValue )
    return colorValue + '0';
 }
 
+const char *colorNameFromValue( int colorValue )
+{
+   switch ( colorValue )
+   {
+      case 16:
+         return "black";
+      case 160:
+         return "red";
+      case 34:
+         return "green";
+      case 220:
+         return "yellow";
+      case 26:
+         return "blue";
+      case 91:
+         return "magenta";
+      case 44:
+         return "cyan";
+      case 231:
+         return "white";
+      case 9:
+         return "default";
+      default:
+         return NULL;
+   }
+}
+
 int colorConfigCalled;
 void colorConfig( void )
 {
@@ -482,6 +509,30 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
    shellKey = '!';
    captureKey = 'c';
    awayKey = 'a';
+   color.text = 34;
+   color.forum = 220;
+   color.number = 44;
+   color.errorTextColor = 160;
+   color.reserved1 = 16;
+   color.reserved2 = 16;
+   color.reserved3 = 16;
+   color.postdate = 91;
+   color.postname = 26;
+   color.posttext = 231;
+   color.postfrienddate = 160;
+   color.postfriendname = 34;
+   color.postfriendtext = 220;
+   color.anonymous = 26;
+   color.moreprompt = 44;
+   color.reserved4 = 16;
+   color.reserved5 = 16;
+   color.background = 9;
+   color.input1 = 231;
+   color.input2 = 34;
+   color.expresstext = 220;
+   color.expressname = 91;
+   color.expressfriendtext = 44;
+   color.expressfriendname = 91;
    flagsConfiguration.shouldUseTcpKeepalive = true;
    flagsConfiguration.shouldEnableClickableUrls = true;
 
@@ -505,6 +556,12 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "writeBbsRc should emit 'clickableurls 1' when clickable URLs are enabled; output was:\n%s", aryOutput );
+      return;
+   }
+   if ( strstr( aryOutput, "\ncolor green yellow cyan red black black black magenta blue white red green yellow blue cyan black black default white green yellow magenta cyan magenta\n" ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "writeBbsRc should emit named colors when palette values have names; output was:\n%s", aryOutput );
       return;
    }
    if ( strstr( aryOutput, "\naryBrowser " ) != NULL )
@@ -545,6 +602,30 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
    shellKey = '!';
    captureKey = 'c';
    awayKey = 'a';
+   color.text = 34;
+   color.forum = 123;
+   color.number = 44;
+   color.errorTextColor = 160;
+   color.reserved1 = 16;
+   color.reserved2 = 16;
+   color.reserved3 = 16;
+   color.postdate = 91;
+   color.postname = 26;
+   color.posttext = 231;
+   color.postfrienddate = 160;
+   color.postfriendname = 34;
+   color.postfriendtext = 220;
+   color.anonymous = 26;
+   color.moreprompt = 44;
+   color.reserved4 = 16;
+   color.reserved5 = 16;
+   color.background = 9;
+   color.input1 = 231;
+   color.input2 = 34;
+   color.expresstext = 220;
+   color.expressname = 91;
+   color.expressfriendtext = 44;
+   color.expressfriendname = 91;
    flagsConfiguration.shouldUseTcpKeepalive = false;
    flagsConfiguration.shouldEnableClickableUrls = false;
 
@@ -568,6 +649,12 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "writeBbsRc should emit 'clickableurls 0' when clickable URLs are disabled; output was:\n%s", aryOutput );
+      return;
+   }
+   if ( strstr( aryOutput, "\ncolor green 123 cyan red black black black magenta blue white red green yellow blue cyan black black default white green yellow magenta cyan magenta\n" ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "writeBbsRc should fall back to numeric palette values when no named color exists; output was:\n%s", aryOutput );
       return;
    }
    if ( strstr( aryOutput, "\naryBrowser " ) != NULL )

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -104,6 +104,11 @@ int colorize( const char *ptrText )
    return 1;
 }
 
+int colorValueToLegacyDigit( int colorValue )
+{
+   return colorValue + '0';
+}
+
 int colorConfigCalled;
 void colorConfig( void )
 {

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -113,6 +113,22 @@ const char *colorNameFromValue( int colorValue )
 {
    switch ( colorValue )
    {
+      case 8:
+         return "brightblack";
+      case 9:
+         return "brightred";
+      case 10:
+         return "brightgreen";
+      case 11:
+         return "brightyellow";
+      case 12:
+         return "brightblue";
+      case 13:
+         return "brightmagenta";
+      case 14:
+         return "brightcyan";
+      case 15:
+         return "brightwhite";
       case 16:
          return "black";
       case 160:
@@ -129,7 +145,7 @@ const char *colorNameFromValue( int colorValue )
          return "cyan";
       case 231:
          return "white";
-      case 9:
+      case COLOR_VALUE_DEFAULT:
          return "default";
       default:
          return NULL;
@@ -509,30 +525,30 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
    shellKey = '!';
    captureKey = 'c';
    awayKey = 'a';
-   color.text = 34;
-   color.forum = 220;
-   color.number = 44;
-   color.errorTextColor = 160;
-   color.reserved1 = 16;
-   color.reserved2 = 16;
-   color.reserved3 = 16;
-   color.postdate = 91;
-   color.postname = 26;
-   color.posttext = 231;
-   color.postfrienddate = 160;
-   color.postfriendname = 34;
-   color.postfriendtext = 220;
-   color.anonymous = 26;
-   color.moreprompt = 44;
-   color.reserved4 = 16;
-   color.reserved5 = 16;
-   color.background = 9;
-   color.input1 = 231;
-   color.input2 = 34;
-   color.expresstext = 220;
-   color.expressname = 91;
-   color.expressfriendtext = 44;
-   color.expressfriendname = 91;
+   color.text = 10;
+   color.forum = 11;
+   color.number = 14;
+   color.errorTextColor = 9;
+   color.reserved1 = 8;
+   color.reserved2 = 8;
+   color.reserved3 = 8;
+   color.postdate = 13;
+   color.postname = 12;
+   color.posttext = 15;
+   color.postfrienddate = 9;
+   color.postfriendname = 10;
+   color.postfriendtext = 11;
+   color.anonymous = 12;
+   color.moreprompt = 14;
+   color.reserved4 = 8;
+   color.reserved5 = 8;
+   color.background = COLOR_VALUE_DEFAULT;
+   color.input1 = 15;
+   color.input2 = 10;
+   color.expresstext = 11;
+   color.expressname = 13;
+   color.expressfriendtext = 14;
+   color.expressfriendname = 13;
    flagsConfiguration.shouldUseTcpKeepalive = true;
    flagsConfiguration.shouldEnableClickableUrls = true;
 
@@ -558,10 +574,10 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
       fail_msg( "writeBbsRc should emit 'clickableurls 1' when clickable URLs are enabled; output was:\n%s", aryOutput );
       return;
    }
-   if ( strstr( aryOutput, "\ncolor green yellow cyan red black black black magenta blue white red green yellow blue cyan black black default white green yellow magenta cyan magenta\n" ) == NULL )
+   if ( strstr( aryOutput, "\ncolor brightgreen brightyellow brightcyan brightred brightblack brightblack brightblack brightmagenta brightblue brightwhite brightred brightgreen brightyellow brightblue brightcyan brightblack brightblack default brightwhite brightgreen brightyellow brightmagenta brightcyan brightmagenta\n" ) == NULL )
    {
       cleanupWriteBbsRcFixture();
-      fail_msg( "writeBbsRc should emit named colors when palette values have names; output was:\n%s", aryOutput );
+      fail_msg( "writeBbsRc should emit bright ANSI color names when palette values have ANSI 16 names; output was:\n%s", aryOutput );
       return;
    }
    if ( strstr( aryOutput, "\naryBrowser " ) != NULL )
@@ -602,30 +618,30 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
    shellKey = '!';
    captureKey = 'c';
    awayKey = 'a';
-   color.text = 34;
+   color.text = 10;
    color.forum = 123;
-   color.number = 44;
-   color.errorTextColor = 160;
-   color.reserved1 = 16;
-   color.reserved2 = 16;
-   color.reserved3 = 16;
-   color.postdate = 91;
-   color.postname = 26;
-   color.posttext = 231;
-   color.postfrienddate = 160;
-   color.postfriendname = 34;
-   color.postfriendtext = 220;
-   color.anonymous = 26;
-   color.moreprompt = 44;
-   color.reserved4 = 16;
-   color.reserved5 = 16;
-   color.background = 9;
-   color.input1 = 231;
-   color.input2 = 34;
-   color.expresstext = 220;
-   color.expressname = 91;
-   color.expressfriendtext = 44;
-   color.expressfriendname = 91;
+   color.number = 14;
+   color.errorTextColor = 9;
+   color.reserved1 = 8;
+   color.reserved2 = 8;
+   color.reserved3 = 8;
+   color.postdate = 13;
+   color.postname = 12;
+   color.posttext = 15;
+   color.postfrienddate = 9;
+   color.postfriendname = 10;
+   color.postfriendtext = 11;
+   color.anonymous = 12;
+   color.moreprompt = 14;
+   color.reserved4 = 8;
+   color.reserved5 = 8;
+   color.background = COLOR_VALUE_DEFAULT;
+   color.input1 = 15;
+   color.input2 = 10;
+   color.expresstext = 11;
+   color.expressname = 13;
+   color.expressfriendtext = 14;
+   color.expressfriendname = 13;
    flagsConfiguration.shouldUseTcpKeepalive = false;
    flagsConfiguration.shouldEnableClickableUrls = false;
 
@@ -651,7 +667,7 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
       fail_msg( "writeBbsRc should emit 'clickableurls 0' when clickable URLs are disabled; output was:\n%s", aryOutput );
       return;
    }
-   if ( strstr( aryOutput, "\ncolor green 123 cyan red black black black magenta blue white red green yellow blue cyan black black default white green yellow magenta cyan magenta\n" ) == NULL )
+   if ( strstr( aryOutput, "\ncolor brightgreen 123 brightcyan brightred brightblack brightblack brightblack brightmagenta brightblue brightwhite brightred brightgreen brightyellow brightblue brightcyan brightblack brightblack default brightwhite brightgreen brightyellow brightmagenta brightcyan brightmagenta\n" ) == NULL )
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "writeBbsRc should fall back to numeric palette values when no named color exists; output was:\n%s", aryOutput );

--- a/test/test_filter.c
+++ b/test/test_filter.c
@@ -648,6 +648,9 @@ static void emitUrlDetectionReport_WhenUrlsCollected_PrintsClickableSummary( voi
 static void emitUrlDetectionReport_WhenAnsiEnabled_UsesConfiguredColorState( void **state )
 {
    // Arrange
+   char aryExpectedBodyColor[32];
+   char aryExpectedHeaderColor[32];
+
    (void)state;
 
    resetState();
@@ -670,11 +673,15 @@ static void emitUrlDetectionReport_WhenAnsiEnabled_UsesConfiguredColorState( voi
    emitUrlDetectionReport();
 
    // Assert
-   if ( strstr( aryPrintLog, "\033[0m\033[36;44m" ) == NULL )
+   formatAnsiDisplayStateSequence( aryExpectedHeaderColor, sizeof( aryExpectedHeaderColor ),
+                                   color.number, color.background, false );
+   formatAnsiDisplayStateSequence( aryExpectedBodyColor, sizeof( aryExpectedBodyColor ),
+                                   color.text, color.background, false );
+   if ( strstr( aryPrintLog, aryExpectedHeaderColor ) == NULL )
    {
       fail_msg( "URL detection report header should use configured number/background colors; log was: %s", aryPrintLog );
    }
-   if ( strstr( aryPrintLog, "\033[0m\033[32;44m" ) == NULL )
+   if ( strstr( aryPrintLog, aryExpectedBodyColor ) == NULL )
    {
       fail_msg( "URL detection report body should use configured text/background colors; log was: %s", aryPrintLog );
    }

--- a/test/test_filter.c
+++ b/test/test_filter.c
@@ -76,7 +76,7 @@ static void resetLists( void )
 }
 
 /* filter.c dependencies not under direct test in this file. */
-char ansiTransform( char inputChar )
+int ansiTransform( int inputChar )
 {
    return inputChar;
 }
@@ -87,7 +87,7 @@ void ansiTransformExpress( char *ptrText, size_t size )
    (void)size;
 }
 
-char ansiTransformPost( char inputChar, int isFriend )
+int ansiTransformPost( int inputChar, int isFriend )
 {
    (void)isFriend;
    return inputChar;
@@ -103,6 +103,11 @@ int colorize( const char *ptrText )
 {
    (void)ptrText;
    return 1;
+}
+
+int colorValueToLegacyDigit( int colorValue )
+{
+   return colorValue + '0';
 }
 
 char *extractName( const char *ptrHeader )
@@ -649,9 +654,9 @@ static void emitUrlDetectionReport_WhenAnsiEnabled_UsesConfiguredColorState( voi
    resetLists();
    flagsConfiguration.useAnsi = 1;
    flagsConfiguration.useBold = 0;
-   color.number = '6';
-   color.text = '2';
-   color.background = '4';
+   color.number = 6;
+   color.text = 2;
+   color.background = 4;
    urlQueue = newQueue( 1024, 5 );
    if ( urlQueue == NULL )
    {

--- a/test/test_filter.c
+++ b/test/test_filter.c
@@ -87,15 +87,29 @@ void ansiTransformExpress( char *ptrText, size_t size )
    (void)size;
 }
 
+int formatTransformedAnsiForegroundSequence( char *ptrBuffer, size_t bufferSize,
+                                             int inputChar, int isPostContext,
+                                             int isFriend )
+{
+   int colorValue;
+
+   (void)isPostContext;
+   (void)isFriend;
+
+   colorValue = inputChar == '6' ? 13 : colorValueFromLegacyDigit( inputChar );
+   return formatAnsiForegroundSequence( ptrBuffer, bufferSize, colorValue );
+}
+
 int ansiTransformPost( int inputChar, int isFriend )
 {
    (void)isFriend;
    return inputChar;
 }
 
-void ansiTransformPostHeader( char *ptrText, int isFriend )
+void ansiTransformPostHeader( char *ptrText, size_t bufferSize, int isFriend )
 {
    (void)ptrText;
+   (void)bufferSize;
    (void)isFriend;
 }
 
@@ -103,6 +117,16 @@ int colorize( const char *ptrText )
 {
    (void)ptrText;
    return 1;
+}
+
+int colorValueFromLegacyDigit( int inputChar )
+{
+   if ( inputChar >= '0' && inputChar <= '9' )
+   {
+      return inputChar - '0';
+   }
+
+   return inputChar;
 }
 
 int colorValueToLegacyDigit( int colorValue )
@@ -718,6 +742,28 @@ static void emitUrlDetectionReport_WhenClickableUrlsDisabled_EmitsNoSummary( voi
    resetLists();
 }
 
+static void filterData_WhenAnsiColorMapsToBrightValue_EmitsFullAnsiSequence( void **state )
+{
+   // Arrange
+   (void)state;
+
+   resetState();
+   color.background = 0;
+
+   // Act
+   filterData( '\033' );
+   filterData( '[' );
+   filterData( '3' );
+   filterData( '6' );
+   filterData( 'm' );
+
+   // Assert
+   if ( strstr( aryPrintLog, "\033[95m" ) == NULL )
+   {
+      fail_msg( "filterData should emit a full bright ANSI sequence for remapped colors; log was: %s", aryPrintLog );
+   }
+}
+
 static void filterExpress_WhenAwayAndIncomingNewMessage_QueuesSender( void **state )
 {
    // Arrange
@@ -781,6 +827,7 @@ int main( void )
       cmocka_unit_test( emitUrlDetectionReport_WhenUrlsCollected_PrintsClickableSummary ),
       cmocka_unit_test( emitUrlDetectionReport_WhenAnsiEnabled_UsesConfiguredColorState ),
       cmocka_unit_test( emitUrlDetectionReport_WhenClickableUrlsDisabled_EmitsNoSummary ),
+      cmocka_unit_test( filterData_WhenAnsiColorMapsToBrightValue_EmitsFullAnsiSequence ),
       cmocka_unit_test( filterExpress_WhenAwayAndIncomingNewMessage_QueuesSender ),
    };
 

--- a/test/test_sysio.c
+++ b/test/test_sysio.c
@@ -25,7 +25,7 @@ static void resetState( void )
    flagsConfiguration.isPosting = 0;
    flagsConfiguration.isMorePromptActive = 0;
    flagsConfiguration.shouldDisableBold = 0;
-   lastColor = '0';
+   lastColor = 0;
 
    if ( tempFile != NULL )
    {
@@ -50,6 +50,16 @@ void fatalPerror( const char *message, const char *heading )
 void tempFileError( void )
 {
    tempFileErrorCallCount++;
+}
+
+int colorValueFromLegacyDigit( int inputChar )
+{
+   if ( inputChar >= '0' && inputChar <= '9' )
+   {
+      return inputChar - '0';
+   }
+
+   return inputChar;
 }
 
 static void stripAnsi_WhenEscapeCodesPresent_RemovesAnsiSequences( void **state )
@@ -142,9 +152,9 @@ static void capPutChar_WhenAnsiSequenceProvided_SkipsAnsiAndTracksLastColor( voi
    {
       fail_msg( "capPutChar should not capture ANSI bytes; expected only payload 'X', got '%s'", aryCaptured );
    }
-   if ( lastColor != '6' )
+   if ( lastColor != 6 )
    {
-      fail_msg( "capPutChar should update lastColor from ANSI code; expected '6', got '%c'", lastColor );
+      fail_msg( "capPutChar should update lastColor from ANSI code; expected 6, got %d", lastColor );
    }
 
    resetState();

--- a/unix.c
+++ b/unix.c
@@ -625,8 +625,12 @@ void setTerm( void )
 
    if ( flagsConfiguration.useAnsi )
    {
-      printf( "\033[%cm\033[3%d;4%dm", flagsConfiguration.useBold ? '1' : '0', lastColor,
-              color.background );
+      char aryAnsiSequence[32];
+
+      formatAnsiDisplayStateSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                      lastColor, color.background,
+                                      flagsConfiguration.useBold );
+      printf( "%s", aryAnsiSequence );
    }
    fflush( stdout );
 
@@ -691,8 +695,10 @@ void resetTerm( void )
 {
    if ( flagsConfiguration.useAnsi )
    {
-      /*	printf("\033[0m\033[1;37;49m"); */
-      printf( "\033[0;39;49m" );
+      char aryAnsiSequence[32];
+
+      formatAnsiResetSequence( aryAnsiSequence, sizeof( aryAnsiSequence ) );
+      printf( "%s", aryAnsiSequence );
    }
    fflush( stdout );
    if ( !isTerminalStateSaved )

--- a/unix.c
+++ b/unix.c
@@ -625,7 +625,7 @@ void setTerm( void )
 
    if ( flagsConfiguration.useAnsi )
    {
-      printf( "\033[%cm\033[3%c;4%cm", flagsConfiguration.useBold ? '1' : '0', lastColor,
+      printf( "\033[%cm\033[3%d;4%dm", flagsConfiguration.useBold ? '1' : '0', lastColor,
               color.background );
    }
    fflush( stdout );

--- a/utility.c
+++ b/utility.c
@@ -563,6 +563,7 @@ char *duplicateString( const char *ptrSource )
 
 int colorize( const char *str )
 {
+   char aryAnsiSequence[32];
    const char *ptrText;
 
    for ( ptrText = str; *ptrText; ptrText++ )
@@ -581,60 +582,132 @@ int colorize( const char *str )
                   putchar( (int)'@' );
                   break;
                case 'k':
-                  ifansi printf( "\033[40m" );
+                  ifansi
+                  {
+                     formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 0 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'K':
-                  ifansi printf( "\033[30m" );
+                  ifansi
+                  {
+                     formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 0 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'r':
-                  ifansi printf( "\033[41m" );
+                  ifansi
+                  {
+                     formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 1 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'R':
-                  ifansi printf( "\033[31m" );
+                  ifansi
+                  {
+                     formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 1 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'g':
-                  ifansi printf( "\033[42m" );
+                  ifansi
+                  {
+                     formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 2 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'G':
-                  ifansi printf( "\033[32m" );
+                  ifansi
+                  {
+                     formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 2 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'y':
-                  ifansi printf( "\033[43m" );
+                  ifansi
+                  {
+                     formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 3 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'Y':
-                  ifansi printf( "\033[33m" );
+                  ifansi
+                  {
+                     formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 3 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'b':
-                  ifansi printf( "\033[44m" );
+                  ifansi
+                  {
+                     formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 4 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'B':
-                  ifansi printf( "\033[34m" );
+                  ifansi
+                  {
+                     formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 4 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'm':
                case 'p':
-                  ifansi printf( "\033[45m" );
+                  ifansi
+                  {
+                     formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 5 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'M':
                case 'P':
-                  ifansi printf( "\033[35m" );
+                  ifansi
+                  {
+                     formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 5 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'c':
-                  ifansi printf( "\033[46m" );
+                  ifansi
+                  {
+                     formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 6 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'C':
-                  ifansi printf( "\033[36m" );
+                  ifansi
+                  {
+                     formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 6 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'w':
-                  ifansi printf( "\033[47m" );
+                  ifansi
+                  {
+                     formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 7 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'W':
-                  ifansi printf( "\033[37m" );
+                  ifansi
+                  {
+                     formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 7 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'd':
-                  ifansi printf( "\033[49m" );
+                  ifansi
+                  {
+                     formatAnsiBackgroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 9 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                case 'D':
-                  ifansi printf( "\033[39m" );
+                  ifansi
+                  {
+                     formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ), 9 );
+                     printf( "%s", aryAnsiSequence );
+                  }
                   break;
                default:
                   break;


### PR DESCRIPTION
Terminal now supports 256 color.
.bbsrc import / export support
While 256 color is not exposed in the menu, ANSI 16 colors _are_.
Added some preset themes to the code, including a colorblind mode.