### PR TITLE
Improve Screen Reader Support

### DIFF
--- a/bbsrc.c
+++ b/bbsrc.c
@@ -594,11 +594,7 @@ void readBbsRc( void )
                      shouldUseSsl = 1;
                   }
                }
-               if ( !strcmp( aryBbsHost, "128.255.200.69" ) ||
-                    !strcmp( aryBbsHost, "128.255.85.69" ) ||
-                    !strcmp( aryBbsHost, "128.255.95.69" ) ||
-                    !strcmp( aryBbsHost, "128.255.3.160" ) ||
-                    !strcmp( aryBbsHost, "bbs.iscabbs.info" ) )
+               if ( !strcmp( aryBbsHost, "206.217.131.27" ) )
                {
                   snprintf( aryBbsHost, sizeof( aryBbsHost ), "%s", BBS_HOSTNAME );
                }

--- a/bbsrc.c
+++ b/bbsrc.c
@@ -43,7 +43,7 @@ static int ctrl( const char *ptrToken )
  * Parses the bbsrc file, setting necessary globals depending on the content of
  * the bbsrc, or returning an error if the bbsrc couldn't be properly parsed.
  */
-#define MAX_LINE_LENGTH 255
+#define MAX_LINE_LENGTH 512
 #define FRIEND_COMMAND_PREFIX_LEN 7
 #define FRIEND_NAME_PARSE_LENGTH 19
 #define FRIEND_INFO_OFFSET 30

--- a/bbsrc.c
+++ b/bbsrc.c
@@ -168,6 +168,7 @@ typedef enum
    BBRC_CMD_SQUELCH,
    BBRC_CMD_SUSP,
    BBRC_CMD_TCP_KEEPALIVE,
+   BBRC_CMD_TITLEBAR,
    BBRC_CMD_URL,
    BBRC_CMD_SCREENREADER,
    BBRC_CMD_VERSION,
@@ -200,6 +201,7 @@ static BbsRcCommandId detectBbsRcCommand( const char *ptrLine )
          { "squelch ", 8, BBRC_CMD_SQUELCH },
          { "keepalive", 9, BBRC_CMD_TCP_KEEPALIVE },
          { "clickableurls", 13, BBRC_CMD_CLICKABLE_URLS },
+         { "titlebar", 8, BBRC_CMD_TITLEBAR },
          { "screenreader", 12, BBRC_CMD_SCREENREADER },
          { "autocomplete", 12, BBRC_CMD_AUTOCOMPLETE },
          { "urlsummary", 10, BBRC_CMD_CLICKABLE_URLS },
@@ -310,6 +312,8 @@ void readBbsRc( void )
    flagsConfiguration.shouldAutoAnswerAnsiPrompt = 0;
    flagsConfiguration.shouldUseTcpKeepalive = 1;
    flagsConfiguration.shouldEnableClickableUrls = 1;
+   flagsConfiguration.shouldEnableTitleBar = 1;
+   flagsConfiguration.hasTitleBarSetting = 0;
    flagsConfiguration.isScreenReaderModeEnabled = 0;
    flagsConfiguration.hasScreenReaderModeSetting = 0;
    flagsConfiguration.shouldEnableNameAutocomplete = 1;
@@ -420,6 +424,48 @@ void readBbsRc( void )
                   else
                   {
                      stdPrintf( "Invalid definition of clickable URL option ignored.\n" );
+                  }
+               }
+               break;
+            }
+
+         case BBRC_CMD_TITLEBAR:
+            {
+               const char *ptrSpace;
+
+               ptrSpace = strchr( aryLine, ' ' );
+               if ( ptrSpace == NULL )
+               {
+                  flagsConfiguration.shouldEnableTitleBar = 1;
+                  flagsConfiguration.hasTitleBarSetting = 1;
+               }
+               else
+               {
+                  const char *ptrTitleBarValue;
+
+                  ptrTitleBarValue = ptrSpace + 1;
+                  while ( *ptrTitleBarValue != '\0' && isspace( (unsigned char)*ptrTitleBarValue ) )
+                  {
+                     ptrTitleBarValue++;
+                  }
+                  if ( *ptrTitleBarValue == '\0' )
+                  {
+                     flagsConfiguration.shouldEnableTitleBar = 1;
+                     flagsConfiguration.hasTitleBarSetting = 1;
+                  }
+                  else if ( *ptrTitleBarValue == '0' )
+                  {
+                     flagsConfiguration.shouldEnableTitleBar = 0;
+                     flagsConfiguration.hasTitleBarSetting = 1;
+                  }
+                  else if ( *ptrTitleBarValue == '1' )
+                  {
+                     flagsConfiguration.shouldEnableTitleBar = 1;
+                     flagsConfiguration.hasTitleBarSetting = 1;
+                  }
+                  else
+                  {
+                     stdPrintf( "Invalid definition of title bar option ignored.\n" );
                   }
                }
                break;
@@ -1086,6 +1132,11 @@ void readBbsRc( void )
    else if ( !flagsConfiguration.hasScreenReaderModeSetting )
    {
       promptForScreenReaderModeIfUnset();
+      shouldRewriteBbsRc = true;
+   }
+   if ( !flagsConfiguration.hasTitleBarSetting )
+   {
+      flagsConfiguration.hasTitleBarSetting = 1;
       shouldRewriteBbsRc = true;
    }
    if ( !flagsConfiguration.hasNameAutocompleteSetting )

--- a/bbsrc.c
+++ b/bbsrc.c
@@ -168,6 +168,7 @@ typedef enum
    BBRC_CMD_SUSP,
    BBRC_CMD_TCP_KEEPALIVE,
    BBRC_CMD_URL,
+   BBRC_CMD_SCREENREADER,
    BBRC_CMD_VERSION,
    BBRC_CMD_XLAND,
    BBRC_CMD_XWRAP
@@ -198,6 +199,7 @@ static BbsRcCommandId detectBbsRcCommand( const char *ptrLine )
          { "squelch ", 8, BBRC_CMD_SQUELCH },
          { "keepalive", 9, BBRC_CMD_TCP_KEEPALIVE },
          { "clickableurls", 13, BBRC_CMD_CLICKABLE_URLS },
+         { "screenreader", 12, BBRC_CMD_SCREENREADER },
          { "urlsummary", 10, BBRC_CMD_CLICKABLE_URLS },
          { "color ", 6, BBRC_CMD_COLOR },
          { "aryAutoName ", sizeof( "aryAutoName " ) - 1, BBRC_CMD_AUTONAME },
@@ -306,6 +308,8 @@ void readBbsRc( void )
    flagsConfiguration.shouldAutoAnswerAnsiPrompt = 0;
    flagsConfiguration.shouldUseTcpKeepalive = 1;
    flagsConfiguration.shouldEnableClickableUrls = 1;
+   flagsConfiguration.isScreenReaderModeEnabled = 0;
+   flagsConfiguration.hasScreenReaderModeSetting = 0;
 
    defaultColors( 1 );
 
@@ -412,6 +416,48 @@ void readBbsRc( void )
                   else
                   {
                      stdPrintf( "Invalid definition of clickable URL option ignored.\n" );
+                  }
+               }
+               break;
+            }
+
+         case BBRC_CMD_SCREENREADER:
+            {
+               const char *ptrSpace;
+
+               ptrSpace = strchr( aryLine, ' ' );
+               if ( ptrSpace == NULL )
+               {
+                  flagsConfiguration.isScreenReaderModeEnabled = 1;
+                  flagsConfiguration.hasScreenReaderModeSetting = 1;
+               }
+               else
+               {
+                  const char *ptrScreenReaderValue;
+
+                  ptrScreenReaderValue = ptrSpace + 1;
+                  while ( *ptrScreenReaderValue != '\0' && isspace( (unsigned char)*ptrScreenReaderValue ) )
+                  {
+                     ptrScreenReaderValue++;
+                  }
+                  if ( *ptrScreenReaderValue == '\0' )
+                  {
+                     flagsConfiguration.isScreenReaderModeEnabled = 1;
+                     flagsConfiguration.hasScreenReaderModeSetting = 1;
+                  }
+                  else if ( *ptrScreenReaderValue == '0' )
+                  {
+                     flagsConfiguration.isScreenReaderModeEnabled = 0;
+                     flagsConfiguration.hasScreenReaderModeSetting = 1;
+                  }
+                  else if ( *ptrScreenReaderValue == '1' )
+                  {
+                     flagsConfiguration.isScreenReaderModeEnabled = 1;
+                     flagsConfiguration.hasScreenReaderModeSetting = 1;
+                  }
+                  else
+                  {
+                     stdPrintf( "Invalid definition of screen reader option ignored.\n" );
                   }
                }
                break;
@@ -994,6 +1040,11 @@ void readBbsRc( void )
       {
          setup( -1 );
       }
+   }
+   else if ( !flagsConfiguration.hasScreenReaderModeSetting )
+   {
+      promptForScreenReaderModeIfUnset();
+      shouldRewriteBbsRc = true;
    }
    if ( shouldShowBrowserMigrationNotice )
    {

--- a/bbsrc.c
+++ b/bbsrc.c
@@ -153,6 +153,7 @@ typedef enum
    BBRC_CMD_CLICKABLE_URLS,
    BBRC_CMD_COLOR,
    BBRC_CMD_COMMANDKEY,
+   BBRC_CMD_AUTOCOMPLETE,
    BBRC_CMD_EDITOR,
    BBRC_CMD_ENEMY,
    BBRC_CMD_FRIEND,
@@ -200,6 +201,7 @@ static BbsRcCommandId detectBbsRcCommand( const char *ptrLine )
          { "keepalive", 9, BBRC_CMD_TCP_KEEPALIVE },
          { "clickableurls", 13, BBRC_CMD_CLICKABLE_URLS },
          { "screenreader", 12, BBRC_CMD_SCREENREADER },
+         { "autocomplete", 12, BBRC_CMD_AUTOCOMPLETE },
          { "urlsummary", 10, BBRC_CMD_CLICKABLE_URLS },
          { "color ", 6, BBRC_CMD_COLOR },
          { "aryAutoName ", sizeof( "aryAutoName " ) - 1, BBRC_CMD_AUTONAME },
@@ -310,6 +312,8 @@ void readBbsRc( void )
    flagsConfiguration.shouldEnableClickableUrls = 1;
    flagsConfiguration.isScreenReaderModeEnabled = 0;
    flagsConfiguration.hasScreenReaderModeSetting = 0;
+   flagsConfiguration.shouldEnableNameAutocomplete = 1;
+   flagsConfiguration.hasNameAutocompleteSetting = 0;
 
    defaultColors( 1 );
 
@@ -458,6 +462,48 @@ void readBbsRc( void )
                   else
                   {
                      stdPrintf( "Invalid definition of screen reader option ignored.\n" );
+                  }
+               }
+               break;
+            }
+
+         case BBRC_CMD_AUTOCOMPLETE:
+            {
+               const char *ptrSpace;
+
+               ptrSpace = strchr( aryLine, ' ' );
+               if ( ptrSpace == NULL )
+               {
+                  flagsConfiguration.shouldEnableNameAutocomplete = 1;
+                  flagsConfiguration.hasNameAutocompleteSetting = 1;
+               }
+               else
+               {
+                  const char *ptrAutocompleteValue;
+
+                  ptrAutocompleteValue = ptrSpace + 1;
+                  while ( *ptrAutocompleteValue != '\0' && isspace( (unsigned char)*ptrAutocompleteValue ) )
+                  {
+                     ptrAutocompleteValue++;
+                  }
+                  if ( *ptrAutocompleteValue == '\0' )
+                  {
+                     flagsConfiguration.shouldEnableNameAutocomplete = 1;
+                     flagsConfiguration.hasNameAutocompleteSetting = 1;
+                  }
+                  else if ( *ptrAutocompleteValue == '0' )
+                  {
+                     flagsConfiguration.shouldEnableNameAutocomplete = 0;
+                     flagsConfiguration.hasNameAutocompleteSetting = 1;
+                  }
+                  else if ( *ptrAutocompleteValue == '1' )
+                  {
+                     flagsConfiguration.shouldEnableNameAutocomplete = 1;
+                     flagsConfiguration.hasNameAutocompleteSetting = 1;
+                  }
+                  else
+                  {
+                     stdPrintf( "Invalid definition of autocomplete option ignored.\n" );
                   }
                }
                break;
@@ -1044,6 +1090,11 @@ void readBbsRc( void )
    else if ( !flagsConfiguration.hasScreenReaderModeSetting )
    {
       promptForScreenReaderModeIfUnset();
+      shouldRewriteBbsRc = true;
+   }
+   if ( !flagsConfiguration.hasNameAutocompleteSetting )
+   {
+      defaultNameAutocompleteIfUnset();
       shouldRewriteBbsRc = true;
    }
    if ( shouldShowBrowserMigrationNotice )

--- a/browser.c
+++ b/browser.c
@@ -113,6 +113,16 @@ static void trimUrlTailPunctuation( char *ptrUrlStart )
    }
 }
 
+static bool shouldEmitClickableUrls( void )
+{
+   if ( flagsConfiguration.isScreenReaderModeEnabled )
+   {
+      return false;
+   }
+
+   return flagsConfiguration.shouldEnableClickableUrls != 0;
+}
+
 void printWithOsc8Links( const char *ptrText )
 {
    const char *ptrCursor;
@@ -121,7 +131,7 @@ void printWithOsc8Links( const char *ptrText )
    {
       return;
    }
-   if ( !flagsConfiguration.shouldEnableClickableUrls )
+   if ( !shouldEmitClickableUrls() )
    {
       stdPrintf( "%s", ptrText );
       return;
@@ -309,7 +319,7 @@ void emitUrlDetectionReport( void )
 {
    char aryUrl[1024];
 
-   if ( !flagsConfiguration.shouldEnableClickableUrls )
+   if ( !shouldEmitClickableUrls() )
    {
       clearDetectedUrlQueue();
       return;

--- a/color.c
+++ b/color.c
@@ -7,7 +7,7 @@
 #include "defs.h"
 #include "ext.h"
 
-static const char *COLOR_MAIN_MENU_KEYS = "gipsoxq \n";
+static const char *COLOR_MAIN_MENU_KEYS = "pgisoxq \n";
 static const char *COLOR_GENERAL_MENU_KEYS = "befntq \n";
 static const char *COLOR_INPUT_MENU_KEYS = "ctq \n";
 static const char *COLOR_POST_MENU_KEYS = "dntq \n";
@@ -559,7 +559,7 @@ void colorConfig( void )
    }
    while ( true )
    {
-      snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n<G>eneral  <I>nput  <P>osts  pre<S>ets  <O>ptions  <X>press  <Q>uit" );
+      snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n<P>resets  <G>eneral  <I>nput  po<S>ts  <O>ptions  <X>press  <Q>uit" );
       printThemedMnemonicText( aryPromptText, color.number );
       printThemedMnemonicText( "\r\nColor config -> ", color.forum );
       printAnsiForegroundColorValue( color.text );
@@ -582,12 +582,12 @@ void colorConfig( void )
             break;
 
          case 'p':
-            stdPrintf( "Post colors\r\n\n" );
-            postColorConfig();
+            presetColorConfig();
             break;
 
          case 's':
-            presetColorConfig();
+            stdPrintf( "Post colors\r\n\n" );
+            postColorConfig();
             break;
 
          case 'x':

--- a/color.c
+++ b/color.c
@@ -40,6 +40,7 @@ typedef struct
 } PresetMenuOption;
 
 static void printAnsiDisplayState( int foregroundColor, int backgroundColor );
+static int transformIncomingAnsiColor( int inputChar );
 
 static const NamedColorSpec aryNamedColors[] =
    {
@@ -334,7 +335,7 @@ static int transformPostHeaderColor( int inputChar, int isFriend )
          }
          return color.posttext;
       default:
-         return colorValueFromLegacyDigit( inputChar );
+         return transformIncomingAnsiColor( inputChar );
    }
 }
 
@@ -406,24 +407,7 @@ int ansiTransform( int inputChar )
 {
    int transformedColor;
 
-   transformedColor = colorValueFromLegacyDigit( inputChar );
-   switch ( inputChar )
-   {
-      case '6':
-         transformedColor = color.number;
-         break;
-      case '3':
-         transformedColor = color.forum;
-         break;
-      case '2':
-         transformedColor = color.text;
-         break;
-      case '1':
-         transformedColor = color.errorTextColor;
-         break;
-      default:
-         break;
-   }
+   transformedColor = transformIncomingAnsiColor( inputChar );
 
    return transformedColor;
 }
@@ -491,7 +475,7 @@ int ansiTransformPost( int inputChar, int isFriend )
 {
    int transformedColor;
 
-   transformedColor = colorValueFromLegacyDigit( inputChar );
+   transformedColor = transformIncomingAnsiColor( inputChar );
    switch ( inputChar )
    {
       case '3':
@@ -514,6 +498,31 @@ int ansiTransformPost( int inputChar, int isFriend )
          break;
    }
    return transformedColor;
+}
+
+static int transformIncomingAnsiColor( int inputChar )
+{
+   switch ( inputChar )
+   {
+      case '0':
+         return color.ansiBlackTextColor;
+      case '1':
+         return color.errorTextColor;
+      case '2':
+         return color.text;
+      case '3':
+         return color.forum;
+      case '4':
+         return color.ansiBlueTextColor;
+      case '5':
+         return color.ansiMagentaTextColor;
+      case '6':
+         return color.number;
+      case '7':
+         return color.ansiWhiteTextColor;
+      default:
+         return colorValueFromLegacyDigit( inputChar );
+   }
 }
 
 void ansiTransformPostHeader( char *ptrText, size_t bufferSize, int isFriend )

--- a/color.c
+++ b/color.c
@@ -30,6 +30,17 @@ typedef struct
    const char *ptrDisplayName;
 } PickerColorOption;
 
+typedef struct
+{
+   int keyChar;
+   const char *ptrLabel;
+   int textColor;
+   int accentColor;
+   int backgroundColor;
+} PresetMenuOption;
+
+static void printAnsiDisplayState( int foregroundColor, int backgroundColor );
+
 static const NamedColorSpec aryNamedColors[] =
    {
       { "brightblack", 8 },
@@ -91,6 +102,13 @@ static const PickerColorOption aryBackgroundPickerOptions[] =
       { '8', 15, "Bright white" },
       { 'd', COLOR_VALUE_DEFAULT, "Default" } };
 
+static const PresetMenuOption aryPresetMenuOptions[] =
+   {
+      { 'd', "Default", 2, 3, 0 },
+      { 'b', "Brilliant", 10, 11, 0 },
+      { 'c', "Colorblind", 231, 75, 16 },
+      { 'h', "Hotdog stand", 220, 196, 16 } };
+
 static bool isColorNameMatch( const char *ptrLeft, const char *ptrRight )
 {
    while ( *ptrLeft && *ptrRight )
@@ -104,6 +122,16 @@ static bool isColorNameMatch( const char *ptrLeft, const char *ptrRight )
    }
 
    return *ptrLeft == '\0' && *ptrRight == '\0';
+}
+
+static void printPresetMenuItem( const PresetMenuOption *ptrOption )
+{
+   stdPrintf( " " );
+   printAnsiDisplayState( ptrOption->textColor, ptrOption->backgroundColor );
+   printAnsiForegroundColorValue( ptrOption->accentColor );
+   stdPrintf( "%c", toupper( ptrOption->keyChar ) );
+   printAnsiForegroundColorValue( ptrOption->textColor );
+   stdPrintf( "%s\r\n", ptrOption->ptrLabel + 1 );
 }
 
 int colorValueFromLegacyDigit( int inputChar )
@@ -215,12 +243,17 @@ static void printBackgroundPickerMenu( void )
 
 static void presetColorConfig( void )
 {
+   size_t optionIndex;
+
    stdPrintf( "Color presets\r\n\n" );
-   printThemedMnemonicText( "<D>efault\r\n", color.number );
-   printThemedMnemonicText( "<B>rilliant\r\n", color.number );
-   printThemedMnemonicText( "<C>olorblind\r\n", color.number );
-   printThemedMnemonicText( "<H>otdog Stand\r\n", color.number );
-   printThemedMnemonicText( "<Q>uit\r\n", color.number );
+   for ( optionIndex = 0;
+         optionIndex < sizeof( aryPresetMenuOptions ) / sizeof( aryPresetMenuOptions[0] );
+         optionIndex++ )
+   {
+      printPresetMenuItem( &aryPresetMenuOptions[optionIndex] );
+   }
+   printAnsiDisplayState( color.text, color.background );
+   printThemedMnemonicText( " Quit\r\n", color.number );
    printThemedMnemonicText( "Select preset -> ", color.forum );
    printAnsiForegroundColorValue( color.text );
 

--- a/color.c
+++ b/color.c
@@ -247,15 +247,6 @@ static void presetColorConfig( void )
    }
 }
 
-static void printAnsiForegroundColor( int colorValue )
-{
-   char aryAnsiSequence[32];
-
-   formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
-                                 colorValue );
-   stdPrintf( "%s", aryAnsiSequence );
-}
-
 static void printAnsiBackgroundColor( int colorValue )
 {
    char aryAnsiSequence[32];
@@ -308,63 +299,63 @@ static void printGeneralColorPreview( void )
 {
    printAnsiDisplayState( color.forum, color.background );
    stdPrintf( "Lobby> " );
-   printAnsiForegroundColor( color.text );
+   printAnsiForegroundColorValue( color.text );
    stdPrintf( "Enter message\r\n\n" );
-   printAnsiForegroundColor( color.errorTextColor );
+   printAnsiForegroundColorValue( color.errorTextColor );
    stdPrintf( "Only Sysops may post to the lobby\r\n\n" );
-   printAnsiForegroundColor( color.forum );
+   printAnsiForegroundColorValue( color.forum );
    stdPrintf( "Lobby> " );
-   printAnsiForegroundColor( color.text );
+   printAnsiForegroundColorValue( color.text );
    stdPrintf( "Goto " );
-   printAnsiForegroundColor( color.forum );
+   printAnsiForegroundColorValue( color.forum );
    stdPrintf( "[Babble]  " );
-   printAnsiForegroundColor( color.number );
+   printAnsiForegroundColorValue( color.number );
    stdPrintf( "150" );
-   printAnsiForegroundColor( color.text );
+   printAnsiForegroundColorValue( color.text );
    stdPrintf( " messages, " );
-   printAnsiForegroundColor( color.number );
+   printAnsiForegroundColorValue( color.number );
    stdPrintf( "1" );
-   printAnsiForegroundColor( color.text );
+   printAnsiForegroundColorValue( color.text );
    stdPrintf( " new\r\n" );
 }
 
 static void printPostColorPreview( int dateColor, int textColor,
                                    int nameColor, const char *ptrName )
 {
-   printAnsiForegroundColor( dateColor );
+   printAnsiForegroundColorValue( dateColor );
    stdPrintf( "Jan  1, 2000 11:01" );
-   printAnsiForegroundColor( textColor );
+   printAnsiForegroundColorValue( textColor );
    stdPrintf( " from " );
-   printAnsiForegroundColor( nameColor );
+   printAnsiForegroundColorValue( nameColor );
    stdPrintf( "%s", ptrName );
-   printAnsiForegroundColor( textColor );
+   printAnsiForegroundColorValue( textColor );
    stdPrintf( "\r\nHi there!\r\n" );
-   printAnsiForegroundColor( color.forum );
+   printAnsiForegroundColorValue( color.forum );
    stdPrintf( "[Lobby> msg #1]\r\n" );
 }
 
 static void printExpressColorPreview( int textColor, int nameColor,
                                       const char *ptrName )
 {
-   printAnsiForegroundColor( textColor );
+   printAnsiForegroundColorValue( textColor );
    stdPrintf( "*** Message (#1) from " );
-   printAnsiForegroundColor( nameColor );
+   printAnsiForegroundColorValue( nameColor );
    stdPrintf( "%s", ptrName );
-   printAnsiForegroundColor( textColor );
+   printAnsiForegroundColorValue( textColor );
    stdPrintf( " at 11:01 ***\r\n>Hi there!\r\n" );
 }
 
 static void printInputColorPreview( void )
 {
-   printAnsiForegroundColor( color.text );
+   printAnsiForegroundColorValue( color.text );
    stdPrintf( "Message eXpress\r\nRecipient: " );
-   printAnsiForegroundColor( color.input1 );
+   printAnsiForegroundColorValue( color.input1 );
    stdPrintf( "Exam" );
-   printAnsiForegroundColor( color.input2 );
+   printAnsiForegroundColorValue( color.input2 );
    stdPrintf( "ple User\r\n" );
-   printAnsiForegroundColor( color.input1 );
+   printAnsiForegroundColorValue( color.input1 );
    stdPrintf( ">Hi there!\r\n" );
-   printAnsiForegroundColor( color.text );
+   printAnsiForegroundColorValue( color.text );
    stdPrintf( "Message received by Example User.\r\n" );
 }
 

--- a/color.c
+++ b/color.c
@@ -216,8 +216,12 @@ static void printBackgroundPickerMenu( void )
 static void presetColorConfig( void )
 {
    stdPrintf( "Color presets\r\n\n" );
-   printThemedMnemonicText( "<D>efault  <B>rilliant  <C>olorblind\r\n", color.number );
-   printThemedMnemonicText( "<H>otdog Stand  <Q>uit -> ", color.number );
+   printThemedMnemonicText( "<D>efault\r\n", color.number );
+   printThemedMnemonicText( "<B>rilliant\r\n", color.number );
+   printThemedMnemonicText( "<C>olorblind\r\n", color.number );
+   printThemedMnemonicText( "<H>otdog Stand\r\n", color.number );
+   printThemedMnemonicText( "<Q>uit\r\n", color.number );
+   printThemedMnemonicText( "Select preset -> ", color.forum );
    printAnsiForegroundColorValue( color.text );
 
    switch ( readValidatedMenuKey( COLOR_RESET_MENU_KEYS ) )

--- a/color.c
+++ b/color.c
@@ -194,27 +194,30 @@ static const PickerColorOption *findPickerColorOption( const PickerColorOption *
 
 static void printForegroundPickerMenu( void )
 {
-   colorize( "\r\n@Y[K]@C Black           @Y[R]@C Red             @Y[G]@C Green           @Y[Y]@C Yellow\r\n" );
-   colorize( "@Y[B]@C Blue            @Y[M]@C Magenta         @Y[C]@C Cyan            @Y[W]@C White\r\n" );
-   colorize( "@Y[1]@C Bright black   @Y[2]@C Bright red      @Y[3]@C Bright green    @Y[4]@C Bright yellow\r\n" );
-   colorize( "@Y[5]@C Bright blue    @Y[6]@C Bright magenta  @Y[7]@C Bright cyan     @Y[8]@C Bright white\r\n" );
-   colorize( "@YSelect color -> @G" );
+   printThemedMnemonicText( "\r\n[<K>] Black           [<R>] Red             [<G>] Green           [<Y>] Yellow\r\n", color.number );
+   printThemedMnemonicText( "[<B>] Blue            [<M>] Magenta         [<C>] Cyan            [<W>] White\r\n", color.number );
+   printThemedMnemonicText( "[<1>] Bright black   [<2>] Bright red      [<3>] Bright green    [<4>] Bright yellow\r\n", color.number );
+   printThemedMnemonicText( "[<5>] Bright blue    [<6>] Bright magenta  [<7>] Bright cyan     [<8>] Bright white\r\n", color.number );
+   printThemedMnemonicText( "Select color -> ", color.forum );
+   printAnsiForegroundColorValue( color.text );
 }
 
 static void printBackgroundPickerMenu( void )
 {
-   colorize( "\r\n@Y[K]@C Black           @Y[R]@C Red             @Y[G]@C Green           @Y[Y]@C Yellow\r\n" );
-   colorize( "@Y[B]@C Blue            @Y[M]@C Magenta         @Y[C]@C Cyan            @Y[W]@C White\r\n" );
-   colorize( "@Y[1]@C Bright black   @Y[2]@C Bright red      @Y[3]@C Bright green    @Y[4]@C Bright yellow\r\n" );
-   colorize( "@Y[5]@C Bright blue    @Y[6]@C Bright magenta  @Y[7]@C Bright cyan     @Y[8]@C Bright white\r\n" );
-   colorize( "@Y[D]@C Default\r\n" );
-   colorize( "@YSelect background -> @G" );
+   printThemedMnemonicText( "\r\n[<K>] Black           [<R>] Red             [<G>] Green           [<Y>] Yellow\r\n", color.number );
+   printThemedMnemonicText( "[<B>] Blue            [<M>] Magenta         [<C>] Cyan            [<W>] White\r\n", color.number );
+   printThemedMnemonicText( "[<1>] Bright black   [<2>] Bright red      [<3>] Bright green    [<4>] Bright yellow\r\n", color.number );
+   printThemedMnemonicText( "[<5>] Bright blue    [<6>] Bright magenta  [<7>] Bright cyan     [<8>] Bright white\r\n", color.number );
+   printThemedMnemonicText( "[<D>] Default\r\n", color.number );
+   printThemedMnemonicText( "Select background -> ", color.forum );
+   printAnsiForegroundColorValue( color.text );
 }
 
 static void presetColorConfig( void )
 {
    stdPrintf( "Color presets\r\n\n" );
-   colorize( "@YD@Cefault  @YC@Colorblind  @YH@Cotdog Stand  @YQ@Cuit@Y -> @G" );
+   printThemedMnemonicText( "<D>efault  <C>olorblind  <H>otdog Stand  <Q>uit -> ", color.number );
+   printAnsiForegroundColorValue( color.text );
 
    switch ( readValidatedMenuKey( COLOR_RESET_MENU_KEYS ) )
    {
@@ -522,8 +525,10 @@ void colorConfig( void )
    }
    while ( true )
    {
-      snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n@YG@Ceneral  @YI@Cnput  @YP@Costs  pre@YS@Cets  @YO@Cptions  @YX@Cpress  @YQ@Cuit\r\n@YColor config -> @G" );
-      colorize( aryPromptText );
+      snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n<G>eneral  <I>nput  <P>osts  pre<S>ets  <O>ptions  <X>press  <Q>uit" );
+      printThemedMnemonicText( aryPromptText, color.number );
+      printThemedMnemonicText( "\r\nColor config -> ", color.forum );
+      printAnsiForegroundColorValue( color.text );
 
       int inputChar = readValidatedMenuKey( COLOR_MAIN_MENU_KEYS );
 
@@ -594,8 +599,9 @@ void generalColorConfig( void )
    {
       printGeneralColorPreview();
 
-      snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n@YB@Cackground  @YE@Crror  @YF@Corum  @YN@Cumber  @YT@Cext  @YQ@Cuit@Y -> @G" );
-      colorize( aryPromptText );
+      snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n<B>ackground  <E>rror  <F>orum  <N>umber  <T>ext  <Q>uit -> " );
+      printThemedMnemonicText( aryPromptText, color.number );
+      printAnsiForegroundColorValue( color.text );
 
       int menuOption = readValidatedMenuKey( COLOR_GENERAL_MENU_KEYS );
 
@@ -641,8 +647,9 @@ void inputColorConfig( void )
    {
       printInputColorPreview();
 
-      snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n@YT@Cext  @YC@Completion  @YQ@Cuit@Y -> @G" );
-      colorize( aryPromptText );
+      snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n<T>ext  <C>ompletion  <Q>uit -> " );
+      printThemedMnemonicText( aryPromptText, color.number );
+      printAnsiForegroundColorValue( color.text );
 
       int menuOption = readValidatedMenuKey( COLOR_INPUT_MENU_KEYS );
 
@@ -753,8 +760,9 @@ char postColorMenu( void )
    int inputChar;
    char aryPromptText[100];
 
-   snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n@YD@Cate  @YN@Came  @YT@Cext  @YQ@Cuit@Y -> @G" );
-   colorize( aryPromptText );
+   snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n<D>ate  <N>ame  <T>ext  <Q>uit -> " );
+   printThemedMnemonicText( aryPromptText, color.number );
+   printAnsiForegroundColorValue( color.text );
 
    inputChar = readValidatedMenuKey( COLOR_POST_MENU_KEYS );
 
@@ -860,8 +868,9 @@ char expressColorMenu( void )
    int inputChar;
    char aryPromptText[100];
 
-   snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n@YN@Came  @YT@Cext  @YQ@Cuit@Y -> @G" );
-   colorize( aryPromptText );
+   snprintf( aryPromptText, sizeof( aryPromptText ), "\r\n<N>ame  <T>ext  <Q>uit -> " );
+   printThemedMnemonicText( aryPromptText, color.number );
+   printAnsiForegroundColorValue( color.text );
 
    inputChar = readValidatedMenuKey( COLOR_EXPRESS_MENU_KEYS );
 
@@ -888,10 +897,13 @@ char expressColorMenu( void )
 char userOrFriend( void )
 {
    int inputChar;
-   char aryPromptText[100];
 
-   snprintf( aryPromptText, sizeof( aryPromptText ), "@GConfigure for @YU@Cser @Gor @YF@Criend @Y-> @G" );
-   colorize( aryPromptText );
+   printThemedMnemonicText( "Configure for ", color.text );
+   printThemedMnemonicText( "<U>ser", color.number );
+   printThemedMnemonicText( " or ", color.text );
+   printThemedMnemonicText( "<F>riend", color.number );
+   printThemedMnemonicText( " -> ", color.forum );
+   printAnsiForegroundColorValue( color.text );
 
    inputChar = readValidatedMenuKey( COLOR_USER_OR_FRIEND_KEYS );
 

--- a/color.c
+++ b/color.c
@@ -12,7 +12,7 @@ static const char *COLOR_GENERAL_MENU_KEYS = "befntq \n";
 static const char *COLOR_INPUT_MENU_KEYS = "ctq \n";
 static const char *COLOR_POST_MENU_KEYS = "dntq \n";
 static const char *COLOR_EXPRESS_MENU_KEYS = "ntq \n";
-static const char *COLOR_RESET_MENU_KEYS = "dchq \n";
+static const char *COLOR_RESET_MENU_KEYS = "dbchq \n";
 static const char *COLOR_USER_OR_FRIEND_KEYS = "ufq \n";
 static const char *COLOR_FOREGROUND_KEYS = "krgybmcw12345678";
 static const char *COLOR_BACKGROUND_KEYS = "krgybmcwd12345678";
@@ -216,7 +216,8 @@ static void printBackgroundPickerMenu( void )
 static void presetColorConfig( void )
 {
    stdPrintf( "Color presets\r\n\n" );
-   printThemedMnemonicText( "<D>efault  <C>olorblind  <H>otdog Stand  <Q>uit -> ", color.number );
+   printThemedMnemonicText( "<D>efault  <B>rilliant  <C>olorblind\r\n", color.number );
+   printThemedMnemonicText( "<H>otdog Stand  <Q>uit -> ", color.number );
    printAnsiForegroundColorValue( color.text );
 
    switch ( readValidatedMenuKey( COLOR_RESET_MENU_KEYS ) )
@@ -224,6 +225,11 @@ static void presetColorConfig( void )
       case 'd':
          stdPrintf( "Default\r\n" );
          defaultColors( 1 );
+         break;
+
+      case 'b':
+         stdPrintf( "Brilliant\r\n" );
+         brilliantColors();
          break;
 
       case 'c':

--- a/color_themes.c
+++ b/color_themes.c
@@ -9,10 +9,10 @@
 /*
  * defaultColors is called once with an arg of 1 before the bbsrc file is
  * read.  This initializes all the color variables.  It is then called again
- * after the bbsrc file is read, with an arg of 0.  This helps with reserved
- * fields which might become used after a user upgrades to a later version
- * which might use those reserved fields. They will get their default values
- * instead of zero, which would render as black.
+ * after the bbsrc file is read, with an arg of 0.  This helps with theme
+ * fields which might become used after a user upgrades to a later version.
+ * They will get their default values instead of zero, which would render
+ * as black.
  */
 #define ifzero( x ) if ( ( x ) < 0 || clearall )
 void defaultColors( int clearall )
@@ -21,9 +21,9 @@ void defaultColors( int clearall )
    ifzero( color.forum ) color.forum = 3;
    ifzero( color.number ) color.number = 6;
    ifzero( color.errorTextColor ) color.errorTextColor = 1;
-   color.reserved1 = 0;
-   color.reserved2 = 0;
-   color.reserved3 = 0;
+   ifzero( color.ansiBlackTextColor ) color.ansiBlackTextColor = 2;
+   ifzero( color.ansiBlueTextColor ) color.ansiBlueTextColor = 4;
+   ifzero( color.ansiMagentaTextColor ) color.ansiMagentaTextColor = 5;
    ifzero( color.postdate ) color.postdate = 5;
    ifzero( color.postname ) color.postname = 6;
    ifzero( color.posttext ) color.posttext = 2;
@@ -32,8 +32,8 @@ void defaultColors( int clearall )
    ifzero( color.postfriendtext ) color.postfriendtext = 2;
    ifzero( color.anonymous ) color.anonymous = 3;
    ifzero( color.moreprompt ) color.moreprompt = 3;
-   color.reserved4 = 0;
-   color.reserved5 = 0;
+   ifzero( color.ansiWhiteTextColor ) color.ansiWhiteTextColor = 7;
+   color.reserved5 = 7;
    if ( clearall )
    {
       color.background = 0;
@@ -52,9 +52,9 @@ void brilliantColors( void )
    color.forum = 11;
    color.number = 14;
    color.errorTextColor = 9;
-   color.reserved1 = 0;
-   color.reserved2 = 0;
-   color.reserved3 = 0;
+   color.ansiBlackTextColor = 10;
+   color.ansiBlueTextColor = 12;
+   color.ansiMagentaTextColor = 13;
    color.postdate = 13;
    color.postname = 14;
    color.posttext = 10;
@@ -63,8 +63,8 @@ void brilliantColors( void )
    color.postfriendtext = 10;
    color.anonymous = 11;
    color.moreprompt = 11;
-   color.reserved4 = 0;
-   color.reserved5 = 0;
+   color.ansiWhiteTextColor = 15;
+   color.reserved5 = 15;
    color.background = 0;
    color.input1 = 10;
    color.input2 = 14;
@@ -80,9 +80,9 @@ void colorblindColors( void )
    color.forum = 75;
    color.number = 214;
    color.errorTextColor = 166;
-   color.reserved1 = 16;
-   color.reserved2 = 16;
-   color.reserved3 = 16;
+   color.ansiBlackTextColor = 146;
+   color.ansiBlueTextColor = 75;
+   color.ansiMagentaTextColor = 175;
    color.postdate = 75;
    color.postname = 214;
    color.posttext = 231;
@@ -91,8 +91,8 @@ void colorblindColors( void )
    color.postfriendtext = 231;
    color.anonymous = 221;
    color.moreprompt = 221;
-   color.reserved4 = 16;
-   color.reserved5 = 16;
+   color.ansiWhiteTextColor = 221;
+   color.reserved5 = 231;
    color.background = 16;
    color.input1 = 231;
    color.input2 = 214;
@@ -108,9 +108,9 @@ void hotDogColors( void )
    color.forum = 196;
    color.number = 220;
    color.errorTextColor = 231;
-   color.reserved1 = 16;
-   color.reserved2 = 16;
-   color.reserved3 = 16;
+   color.ansiBlackTextColor = 130;
+   color.ansiBlueTextColor = 214;
+   color.ansiMagentaTextColor = 130;
    color.postdate = 226;
    color.postname = 226;
    color.posttext = 214;
@@ -119,8 +119,8 @@ void hotDogColors( void )
    color.postfriendtext = 214;
    color.anonymous = 226;
    color.moreprompt = 220;
-   color.reserved4 = 16;
-   color.reserved5 = 16;
+   color.ansiWhiteTextColor = 220;
+   color.reserved5 = 130;
    color.background = 16;
    color.input1 = 220;
    color.input2 = 231;

--- a/color_themes.c
+++ b/color_themes.c
@@ -67,7 +67,7 @@ void colorblindColors( void )
    color.reserved5 = 16;
    color.background = 16;
    color.input1 = 231;
-   color.input2 = 36;
+   color.input2 = 214;
    color.expresstext = 231;
    color.expressname = 214;
    color.expressfriendname = 175;

--- a/color_themes.c
+++ b/color_themes.c
@@ -46,6 +46,34 @@ void defaultColors( int clearall )
    ifzero( color.expressfriendtext ) color.expressfriendtext = 2;
 }
 
+void brilliantColors( void )
+{
+   color.text = 10;
+   color.forum = 11;
+   color.number = 14;
+   color.errorTextColor = 9;
+   color.reserved1 = 0;
+   color.reserved2 = 0;
+   color.reserved3 = 0;
+   color.postdate = 13;
+   color.postname = 14;
+   color.posttext = 10;
+   color.postfrienddate = 13;
+   color.postfriendname = 9;
+   color.postfriendtext = 10;
+   color.anonymous = 11;
+   color.moreprompt = 11;
+   color.reserved4 = 0;
+   color.reserved5 = 0;
+   color.background = 0;
+   color.input1 = 10;
+   color.input2 = 14;
+   color.expresstext = 10;
+   color.expressname = 10;
+   color.expressfriendname = 10;
+   color.expressfriendtext = 10;
+}
+
 void colorblindColors( void )
 {
    color.text = 231;

--- a/config.c
+++ b/config.c
@@ -178,15 +178,9 @@ void configBbsRc( void )
    }
    while ( true )
    {
-      if ( flagsConfiguration.useAnsi )
-      {
-         colorize( "\r\n@YC@Color  @YE@Cnemy list  @YF@Criend list  @YH@Cotkeys\r\n@YI@Cnfo  @YM@Cacros  @YO@Cptions  @YX@Cpress  @YQ@Cuit@Y" );
-      }
-      else
-      {
-         stdPrintf( "\r\n<C>olor <E>nemy list <F>riend list <H>otkeys\r\n<I>nfo  <M>acros <O>ptions <X>press <Q>uit" );
-      }
-      colorize( "\r\nClient config -> @G" );
+      printThemedMnemonicText( "\r\n<C>olor  <E>nemy list  <F>riend list  <H>otkeys\r\n<I>nfo  <M>acros  <O>ptions  <X>press  <Q>uit", color.number );
+      printThemedMnemonicText( "\r\nClient config -> ", color.forum );
+      printAnsiForegroundColorValue( color.text );
       inputChar = readValidatedMenuKey( CONFIG_MAIN_MENU_KEYS );
       switch ( inputChar )
       {
@@ -347,7 +341,9 @@ void configBbsRc( void )
             {
                if ( flagsConfiguration.useAnsi )
                {
-                  colorize( "\r\n@YE@Cdit  @YL@Cist  @YQ@Cuit\r\n@YMacro config -> @G" );
+                  printThemedMnemonicText( "\r\n<E>dit  <L>ist  <Q>uit", color.number );
+                  printThemedMnemonicText( "\r\nMacro config -> ", color.forum );
+                  printAnsiForegroundColorValue( color.text );
                }
                else
                {
@@ -428,14 +424,9 @@ void expressConfig( void )
 
    while ( true )
    {
-      if ( flagsConfiguration.useAnsi )
-      {
-         colorize( "\r\n@YA@Cway  @YX@CLand  @YQ@Cuit\r\n@YExpress config -> @G" );
-      }
-      else
-      {
-         stdPrintf( "\r\n<A>way <X>Land <Q>uit\r\nExpress config -> " );
-      }
+      printThemedMnemonicText( "\r\n<A>way  <X>Land  <Q>uit", color.number );
+      printThemedMnemonicText( "\r\nExpress config -> ", color.forum );
+      printAnsiForegroundColorValue( color.text );
 
       int inputChar = readValidatedMenuKey( CONFIG_EXPRESS_MENU_KEYS );
 
@@ -740,25 +731,15 @@ void editUsers( slist *list, int ( *findfn )( const void *, const void * ), cons
       /* Build menu */
       if ( !strncmp( name, "enemy", 5 ) )
       {
-         if ( flagsConfiguration.useAnsi )
-         {
-            colorize( "\r\n@YA@Cdd  @YD@Celete  @YL@Cist  @YO@Cptions  @YQ@Cuit@Y" );
-         }
-         else
-         {
-            stdPrintf( "\r\n<A>dd <D>elete <L>ist <O>ptions <Q>uit" );
-         }
-      }
-      else if ( flagsConfiguration.useAnsi )
-      {
-         colorize( "\r\n@YA@Cdd  @YD@Celete  @YE@Cdit  @YL@Cist  @YQ@Cuit@Y" );
+         printThemedMnemonicText( "\r\n<A>dd  <D>elete  <L>ist  <O>ptions  <Q>uit", color.number );
       }
       else
       {
-         stdPrintf( "\r\n<A>dd <D>elete <E>dit <L>ist <Q>uit" );
+         printThemedMnemonicText( "\r\n<A>dd  <D>elete  <E>dit  <L>ist  <Q>uit", color.number );
       }
-      snprintf( aryDisplayLine, sizeof( aryDisplayLine ), "\r\n%c%s list -> @G", toupper( name[0] ), name + 1 );
-      colorize( aryDisplayLine );
+      snprintf( aryDisplayLine, sizeof( aryDisplayLine ), "\r\n%c%s list -> ", toupper( name[0] ), name + 1 );
+      printThemedMnemonicText( aryDisplayLine, color.forum );
+      printAnsiForegroundColorValue( color.text );
 
       inputChar = inKey();
       switch ( inputChar )

--- a/config.c
+++ b/config.c
@@ -204,9 +204,19 @@ void configBbsRc( void )
 
          case 'o':
             stdPrintf( "Options\r\n" );
+            stdPrintf( "Use screen reader friendly mode? (%s) -> ",
+                       flagsConfiguration.isScreenReaderModeEnabled ? "Yes" : "No" );
+            flagsConfiguration.isScreenReaderModeEnabled =
+               (unsigned int)yesNoDefault( flagsConfiguration.isScreenReaderModeEnabled );
+            flagsConfiguration.hasScreenReaderModeSetting = 1;
+            if ( flagsConfiguration.isScreenReaderModeEnabled )
+            {
+               flagsConfiguration.shouldEnableClickableUrls = 0;
+               flagsConfiguration.shouldEnableNameAutocomplete = 0;
+            }
             if ( !isLoginShell )
             {
-               stdPrintf( "\r\nEnter name of local editor to use (%s) -> ", aryEditor );
+               stdPrintf( "Enter name of local editor to use (%s) -> ", aryEditor );
                getString( 72, aryMenuLine, -999 );
                if ( *aryMenuLine )
                {
@@ -285,10 +295,6 @@ void configBbsRc( void )
             stdPrintf( "Append OSC 8 URL summaries to posts & mail? (%s) -> ",
                        flagsConfiguration.shouldEnableClickableUrls ? "Yes" : "No" );
             flagsConfiguration.shouldEnableClickableUrls = (unsigned int)yesNoDefault( flagsConfiguration.shouldEnableClickableUrls );
-            stdPrintf( "Use screen reader friendly mode? (%s) -> ",
-                       flagsConfiguration.isScreenReaderModeEnabled ? "Yes" : "No" );
-            flagsConfiguration.isScreenReaderModeEnabled = (unsigned int)yesNoDefault( flagsConfiguration.isScreenReaderModeEnabled );
-            flagsConfiguration.hasScreenReaderModeSetting = 1;
             stdPrintf( "Autocomplete username in recipient prompts? (%s) -> ",
                        flagsConfiguration.shouldEnableNameAutocomplete ? "Yes" : "No" );
             flagsConfiguration.shouldEnableNameAutocomplete =

--- a/config.c
+++ b/config.c
@@ -339,16 +339,9 @@ void configBbsRc( void )
             stdPrintf( "Macros\r\n" );
             for ( ; inputChar != 'q'; )
             {
-               if ( flagsConfiguration.useAnsi )
-               {
-                  printThemedMnemonicText( "\r\n<E>dit  <L>ist  <Q>uit", color.number );
-                  printThemedMnemonicText( "\r\nMacro config -> ", color.forum );
-                  printAnsiForegroundColorValue( color.text );
-               }
-               else
-               {
-                  stdPrintf( "\r\n<E>dit <L>ist <Q>uit\r\nMacro config -> " );
-               }
+               printThemedMnemonicText( "\r\n<E>dit  <L>ist  <Q>uit", color.number );
+               printThemedMnemonicText( "\r\nMacro config -> ", color.forum );
+               printAnsiForegroundColorValue( color.text );
                inputChar = readValidatedMenuKey( CONFIG_MACRO_MENU_KEYS );
                switch ( inputChar )
                {

--- a/config.c
+++ b/config.c
@@ -68,6 +68,18 @@ void promptForScreenReaderModeIfUnset( void )
    flagsConfiguration.hasScreenReaderModeSetting = 1;
 }
 
+void defaultNameAutocompleteIfUnset( void )
+{
+   if ( flagsConfiguration.hasNameAutocompleteSetting )
+   {
+      return;
+   }
+
+   flagsConfiguration.shouldEnableNameAutocomplete =
+      (unsigned int)!flagsConfiguration.isScreenReaderModeEnabled;
+   flagsConfiguration.hasNameAutocompleteSetting = 1;
+}
+
 /*
  * First time setup borrowed from Client 9 with permission.
  */
@@ -131,6 +143,7 @@ void setup( int newVersion )
       sInfo( aryUrlInfo, "Websites" );
    }
    promptForScreenReaderModeIfUnset();
+   defaultNameAutocompleteIfUnset();
    if ( sPrompt( ADVANCED_OPTIONS, "Configure the client now?", 0 ) )
    {
       configBbsRc();
@@ -276,6 +289,11 @@ void configBbsRc( void )
                        flagsConfiguration.isScreenReaderModeEnabled ? "Yes" : "No" );
             flagsConfiguration.isScreenReaderModeEnabled = (unsigned int)yesNoDefault( flagsConfiguration.isScreenReaderModeEnabled );
             flagsConfiguration.hasScreenReaderModeSetting = 1;
+            stdPrintf( "Autocomplete username in recipient prompts? (%s) -> ",
+                       flagsConfiguration.shouldEnableNameAutocomplete ? "Yes" : "No" );
+            flagsConfiguration.shouldEnableNameAutocomplete =
+               (unsigned int)yesNoDefault( flagsConfiguration.shouldEnableNameAutocomplete );
+            flagsConfiguration.hasNameAutocompleteSetting = 1;
             break;
 
          case 'h':
@@ -496,6 +514,7 @@ void writeBbsRc( void )
    fprintf( ptrBbsRc, "keepalive %d\n", flagsConfiguration.shouldUseTcpKeepalive ? 1 : 0 );
    fprintf( ptrBbsRc, "clickableurls %d\n", flagsConfiguration.shouldEnableClickableUrls ? 1 : 0 );
    fprintf( ptrBbsRc, "screenreader %d\n", flagsConfiguration.isScreenReaderModeEnabled ? 1 : 0 );
+   fprintf( ptrBbsRc, "autocomplete %d\n", flagsConfiguration.shouldEnableNameAutocomplete ? 1 : 0 );
    if ( *aryAutoName )
    {
       fprintf( ptrBbsRc, "aryAutoName %s\n", aryAutoName );

--- a/config.c
+++ b/config.c
@@ -29,6 +29,8 @@ static const char *CONFIG_EXPRESS_MENU_KEYS = "axq \n";
    "You can now turn off the notification of killed posts and express messages\r\nfrom people on your enemy list.\r\n\nSelect Yes to be notified, or No to not be notified."
 #define ADVANCED_OPTIONS \
    "Advanced users may wish to use the configuration menu now to change options\r\nbefore logging in."
+#define SCREEN_READER_INFO \
+   "Screen reader friendly mode keeps this client easier for VoiceOver and other\r\nscreen readers to follow.  You can change this later from the Options menu."
 
 static const char *describeKeyForHelp( int inputChar )
 {
@@ -50,6 +52,20 @@ static const char *describeKeyForHelp( int inputChar )
       default:
          return strCtrl( inputChar );
    }
+}
+
+void promptForScreenReaderModeIfUnset( void )
+{
+   if ( flagsConfiguration.hasScreenReaderModeSetting )
+   {
+      return;
+   }
+
+   flagsConfiguration.isScreenReaderModeEnabled =
+      (unsigned int)sPrompt( SCREEN_READER_INFO,
+                             "Use screen reader friendly mode?",
+                             0 );
+   flagsConfiguration.hasScreenReaderModeSetting = 1;
 }
 
 /*
@@ -114,6 +130,7 @@ void setup( int newVersion )
                 describeKeyForHelp( browserKey ) );
       sInfo( aryUrlInfo, "Websites" );
    }
+   promptForScreenReaderModeIfUnset();
    if ( sPrompt( ADVANCED_OPTIONS, "Configure the client now?", 0 ) )
    {
       configBbsRc();
@@ -255,6 +272,10 @@ void configBbsRc( void )
             stdPrintf( "Append OSC 8 URL summaries to posts & mail? (%s) -> ",
                        flagsConfiguration.shouldEnableClickableUrls ? "Yes" : "No" );
             flagsConfiguration.shouldEnableClickableUrls = (unsigned int)yesNoDefault( flagsConfiguration.shouldEnableClickableUrls );
+            stdPrintf( "Use screen reader friendly mode? (%s) -> ",
+                       flagsConfiguration.isScreenReaderModeEnabled ? "Yes" : "No" );
+            flagsConfiguration.isScreenReaderModeEnabled = (unsigned int)yesNoDefault( flagsConfiguration.isScreenReaderModeEnabled );
+            flagsConfiguration.hasScreenReaderModeSetting = 1;
             break;
 
          case 'h':
@@ -474,6 +495,7 @@ void writeBbsRc( void )
    fprintf( ptrBbsRc, "squelch %d\n", ( flagsConfiguration.shouldSquelchPost ? 2 : 0 ) + ( flagsConfiguration.shouldSquelchExpress ? 1 : 0 ) );
    fprintf( ptrBbsRc, "keepalive %d\n", flagsConfiguration.shouldUseTcpKeepalive ? 1 : 0 );
    fprintf( ptrBbsRc, "clickableurls %d\n", flagsConfiguration.shouldEnableClickableUrls ? 1 : 0 );
+   fprintf( ptrBbsRc, "screenreader %d\n", flagsConfiguration.isScreenReaderModeEnabled ? 1 : 0 );
    if ( *aryAutoName )
    {
       fprintf( ptrBbsRc, "aryAutoName %s\n", aryAutoName );

--- a/config.c
+++ b/config.c
@@ -286,6 +286,11 @@ void configBbsRc( void )
             stdPrintf( "Try to keep idle connections alive with TCP probes? (%s) -> ",
                        flagsConfiguration.shouldUseTcpKeepalive ? "Yes" : "No" );
             flagsConfiguration.shouldUseTcpKeepalive = (unsigned int)yesNoDefault( flagsConfiguration.shouldUseTcpKeepalive );
+            flagsConfiguration.hasTitleBarSetting = 1;
+            stdPrintf( "Update terminal title bar? (%s) -> ",
+                       flagsConfiguration.shouldEnableTitleBar ? "Yes" : "No" );
+            flagsConfiguration.shouldEnableTitleBar =
+               (unsigned int)yesNoDefault( flagsConfiguration.shouldEnableTitleBar );
             stdPrintf( "Append OSC 8 URL summaries to posts & mail? (%s) -> ",
                        flagsConfiguration.shouldEnableClickableUrls ? "Yes" : "No" );
             flagsConfiguration.shouldEnableClickableUrls = (unsigned int)yesNoDefault( flagsConfiguration.shouldEnableClickableUrls );
@@ -503,6 +508,7 @@ void writeBbsRc( void )
    fprintf( ptrBbsRc, "squelch %d\n", ( flagsConfiguration.shouldSquelchPost ? 2 : 0 ) + ( flagsConfiguration.shouldSquelchExpress ? 1 : 0 ) );
    fprintf( ptrBbsRc, "keepalive %d\n", flagsConfiguration.shouldUseTcpKeepalive ? 1 : 0 );
    fprintf( ptrBbsRc, "clickableurls %d\n", flagsConfiguration.shouldEnableClickableUrls ? 1 : 0 );
+   fprintf( ptrBbsRc, "titlebar %d\n", flagsConfiguration.shouldEnableTitleBar ? 1 : 0 );
    fprintf( ptrBbsRc, "screenreader %d\n", flagsConfiguration.isScreenReaderModeEnabled ? 1 : 0 );
    fprintf( ptrBbsRc, "autocomplete %d\n", flagsConfiguration.shouldEnableNameAutocomplete ? 1 : 0 );
    if ( *aryAutoName )

--- a/config.h
+++ b/config.h
@@ -4,9 +4,6 @@
 /* Define this if you want to enable saving passwords */
 /* #undef ENABLE_SAVE_PASSWORD */
 
-/* Define this if you want to use xterm/NeXT titlebars */
-#define ENABLE_TITLEBAR 1
-
 /* Define if cmocka is available for unit tests */
 #define HAVE_CMOCKA 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,6 @@ AC_ARG_WITH(ssl,
    	fi
    ]
 )
-AC_ARG_ENABLE(titlebar, [  --disable-titlebar      disable xterm/NeXT titlebar (default is enabled)])
 AC_ARG_ENABLE(save-password, [  --enable-save-password  allow passwords to be saved])
 
 dnl Checks for programs.
@@ -37,7 +36,7 @@ AC_CHECK_LIB(util, main)
 
 PLATFORM_OBJS="unix.o"
 
-# Some target-specific stuff
+#Some target - specific stuff
 case "$host_os" in
 netbsd*)
    need_dash_r=1;
@@ -48,7 +47,7 @@ solaris*)
 esac
 
 if test x$with_ssl = xyes; then
-   # The big search for OpenSSL
+#The big search for OpenSSL
    saved_LIBS="$LIBS"
    saved_LDFLAGS="$LDFLAGS"
    saved_CFLAGS="$CFLAGS"
@@ -61,13 +60,13 @@ if test x$with_ssl = xyes; then
    		LDFLAGS="$saved_LDFLAGS"
    		LIBS="$saved_LIBS -lssl -lcrypto"
 
-   		# Skip directories if they don't exist
+#Skip directories if they don't exist
    		if test ! -z "$ssldir" -a ! -d "$ssldir" ; then
    			continue;
    		fi
    		if test ! -z "$ssldir" -a "x$ssldir" != "x/usr"; then
-   			# Try to use $ssldir/lib if it exists, otherwise
-   			# $ssldir
+#Try to use $ssldir / lib if it exists, otherwise
+#$ssldir
    			if test -d "$ssldir/lib" ; then
    				LDFLAGS="-L$ssldir/lib $saved_LDFLAGS"
    				if test ! -z "$need_dash_r" ; then
@@ -79,8 +78,8 @@ if test x$with_ssl = xyes; then
    					LDFLAGS="-R$ssldir $LDFLAGS"
    				fi
    			fi
-   			# Try to use $ssldir/include if it exists,
-   			# otherwise $ssldir
+#Try to use $ssldir / include if it exists,
+#otherwise $ssldir
    			if test -d "$ssldir/include" ; then
    				CFLAGS="-I$ssldir/include $saved_CFLAGS"
    			else
@@ -88,9 +87,9 @@ if test x$with_ssl = xyes; then
    			fi
    		fi
 
-   		# Basic test to check for compatible version and
-   		# correct linking *does not* test for RSA - that
-   		# comes later.
+#Basic test to check for compatible version and
+#correct linking *does not *test for RSA - that
+#comes later.
    		AC_RUN_IFELSE(
    			[AC_LANG_SOURCE([[
 #include <string.h>
@@ -137,8 +136,8 @@ if test "x$ac_cv_openssldir" != "xno" ; then
    dnl Need to recover ssldir - test above runs in subshell
    ssldir=$ac_cv_openssldir
    if test ! -z "$ssldir" -a "x$ssldir" != "x/usr" -a "x$ssldir" != "x(system)"; then
-   	# Try to use $ssldir/lib if it exists, otherwise
-   	# $ssldir
+#Try to use $ssldir / lib if it exists, otherwise
+#$ssldir
    	if test -d "$ssldir/lib" ; then
    		LDFLAGS="-L$ssldir/lib $saved_LDFLAGS"
    		if test ! -z "$need_dash_r" ; then
@@ -150,8 +149,8 @@ if test "x$ac_cv_openssldir" != "xno" ; then
    			LDFLAGS="-R$ssldir $LDFLAGS"
    		fi
    	fi
-   	# Try to use $ssldir/include if it exists, otherwise
-   	# $ssldir
+#Try to use $ssldir / include if it exists, otherwise
+#$ssldir
    	if test -d "$ssldir/include" ; then
    		CFLAGS="-I$ssldir/include $saved_CFLAGS"
    	else
@@ -163,10 +162,6 @@ fi
 
 if test x$enable_save_password = xyes; then
    AC_DEFINE(ENABLE_SAVE_PASSWORD,[1],[Define this if you want to enable saving passwords])
-fi
-
-if test x$enable_titlebar != xno; then
-   AC_DEFINE(ENABLE_TITLEBAR,[1],[Define this if you want to use xterm/NeXT titlebars])
 fi
 
 dnl Checks for header files.

--- a/defs.h
+++ b/defs.h
@@ -261,7 +261,9 @@ typedef struct
    unsigned int shouldAutoAnswerAnsiPrompt : 1;   /* true if we automatically answer ANSI ? */
    unsigned int shouldUseTcpKeepalive : 1;        /* true if TCP keepalive probes are enabled */
    unsigned int shouldEnableClickableUrls : 1;    /* true if OSC-8 clickable URL output is enabled */
+   unsigned int shouldEnableTitleBar : 1;         /* true if terminal title updates are enabled */
    unsigned int isScreenReaderModeEnabled : 1;    /* true if screen reader friendly mode is enabled */
+   unsigned int hasTitleBarSetting : 1;           /* true if title bar setting was set in .bbsrc */
    unsigned int hasScreenReaderModeSetting : 1;   /* true if screen reader mode was set in .bbsrc */
    unsigned int shouldEnableNameAutocomplete : 1; /* true if name-entry autocomplete is enabled */
    unsigned int hasNameAutocompleteSetting : 1;   /* true if name autocomplete was set in .bbsrc */

--- a/defs.h
+++ b/defs.h
@@ -222,7 +222,7 @@ typedef struct
 #define ALLOWED_INPUT_CONTROL_CHARS "\3\4\5\b\n\r\27\30\32"
 
 #define BBS_HOSTNAME "bbs.iscabbs.com"
-#define BBS_IP_ADDRESS "64.198.88.46"
+#define BBS_IP_ADDRESS "206.217.131.27"
 #define BBS_PORT_NUMBER 23
 #define SSL_PORT_NUMBER 992
 

--- a/defs.h
+++ b/defs.h
@@ -287,22 +287,22 @@ typedef struct
 
 typedef struct
 {
-   int text;           /* Plain text color */
-   int forum;          /* Forum prompt color */
-   int number;         /* Numbers and Read cmd prompt color */
-   int errorTextColor; /* Warning/error messages color */
-   int reserved1;
-   int reserved2;
-   int reserved3;
-   int postdate;       /* Post date stamp color */
-   int postname;       /* Post author name color */
-   int posttext;       /* Post text color */
-   int postfrienddate; /* Post friend date stamp color */
-   int postfriendname; /* Post friend name color */
-   int postfriendtext; /* Post friend text color */
-   int anonymous;      /* Anonymous post header color */
-   int moreprompt;     /* More prompt color */
-   int reserved4;
+   int text;                 /* Plain text color */
+   int forum;                /* Forum prompt color */
+   int number;               /* Numbers and Read cmd prompt color */
+   int errorTextColor;       /* Warning/error messages color */
+   int ansiBlackTextColor;   /* Incoming ANSI black fallback color */
+   int ansiBlueTextColor;    /* Incoming ANSI blue fallback color */
+   int ansiMagentaTextColor; /* Incoming ANSI magenta fallback color */
+   int postdate;             /* Post date stamp color */
+   int postname;             /* Post author name color */
+   int posttext;             /* Post text color */
+   int postfrienddate;       /* Post friend date stamp color */
+   int postfriendname;       /* Post friend name color */
+   int postfriendtext;       /* Post friend text color */
+   int anonymous;            /* Anonymous post header color */
+   int moreprompt;           /* More prompt color */
+   int ansiWhiteTextColor;   /* Incoming ANSI white fallback color */
    int reserved5;
    int background;        /* Background color */
    int input1;            /* Text input fields */

--- a/defs.h
+++ b/defs.h
@@ -248,21 +248,23 @@ typedef struct
 #define NAWS_ROWS_MAX 110
 typedef struct
 {
-   unsigned int isPosting : 1;                  /* true if aryUser is currently posting */
-   unsigned int isLastSave : 1;                 /* true if last time aryUser edited they saved */
-   unsigned int shouldCheckExpress : 1;         /* true if waiting to check BBS for X's */
-   unsigned int isConfigMode : 1;               /* true if we are in bbsrc config funcs */
-   unsigned int useAnsi : 1;                    /* true if BBS is in ANSI color mode */
-   unsigned int useBold : 1;                    /* true if using bold in ANSI color mode */
-   unsigned int shouldDisableBold : 1;          /* true if we need to force bold ANSI off */
-   unsigned int isMorePromptActive : 1;         /* true if we are inside a MORE prompt */
-   unsigned int shouldSquelchPost : 1;          /* true if we should squelch enemy posts */
-   unsigned int shouldSquelchExpress : 1;       /* true if we should squelch enemy express */
-   unsigned int shouldAutoAnswerAnsiPrompt : 1; /* true if we automatically answer ANSI ? */
-   unsigned int shouldUseTcpKeepalive : 1;      /* true if TCP keepalive probes are enabled */
-   unsigned int shouldEnableClickableUrls : 1;  /* true if OSC-8 clickable URL output is enabled */
-   unsigned int isScreenReaderModeEnabled : 1;  /* true if screen reader friendly mode is enabled */
-   unsigned int hasScreenReaderModeSetting : 1; /* true if screen reader mode was set in .bbsrc */
+   unsigned int isPosting : 1;                    /* true if aryUser is currently posting */
+   unsigned int isLastSave : 1;                   /* true if last time aryUser edited they saved */
+   unsigned int shouldCheckExpress : 1;           /* true if waiting to check BBS for X's */
+   unsigned int isConfigMode : 1;                 /* true if we are in bbsrc config funcs */
+   unsigned int useAnsi : 1;                      /* true if BBS is in ANSI color mode */
+   unsigned int useBold : 1;                      /* true if using bold in ANSI color mode */
+   unsigned int shouldDisableBold : 1;            /* true if we need to force bold ANSI off */
+   unsigned int isMorePromptActive : 1;           /* true if we are inside a MORE prompt */
+   unsigned int shouldSquelchPost : 1;            /* true if we should squelch enemy posts */
+   unsigned int shouldSquelchExpress : 1;         /* true if we should squelch enemy express */
+   unsigned int shouldAutoAnswerAnsiPrompt : 1;   /* true if we automatically answer ANSI ? */
+   unsigned int shouldUseTcpKeepalive : 1;        /* true if TCP keepalive probes are enabled */
+   unsigned int shouldEnableClickableUrls : 1;    /* true if OSC-8 clickable URL output is enabled */
+   unsigned int isScreenReaderModeEnabled : 1;    /* true if screen reader friendly mode is enabled */
+   unsigned int hasScreenReaderModeSetting : 1;   /* true if screen reader mode was set in .bbsrc */
+   unsigned int shouldEnableNameAutocomplete : 1; /* true if name-entry autocomplete is enabled */
+   unsigned int hasNameAutocompleteSetting : 1;   /* true if name autocomplete was set in .bbsrc */
 } Flags;
 
 typedef struct

--- a/defs.h
+++ b/defs.h
@@ -261,6 +261,8 @@ typedef struct
    unsigned int shouldAutoAnswerAnsiPrompt : 1; /* true if we automatically answer ANSI ? */
    unsigned int shouldUseTcpKeepalive : 1;      /* true if TCP keepalive probes are enabled */
    unsigned int shouldEnableClickableUrls : 1;  /* true if OSC-8 clickable URL output is enabled */
+   unsigned int isScreenReaderModeEnabled : 1;  /* true if screen reader friendly mode is enabled */
+   unsigned int hasScreenReaderModeSetting : 1; /* true if screen reader mode was set in .bbsrc */
 } Flags;
 
 typedef struct

--- a/edit.c
+++ b/edit.c
@@ -373,7 +373,7 @@ int prompt( FILE *ptrMessageFile, int *previousChar, int commandChar )
             while ( true )
             {
                inputChar = readFoldedKey();
-               if ( findChar( " \nacepqtx?/", inputChar ) )
+               if ( findChar( " \nacepsqtx?/", inputChar ) )
                {
                   break;
                }
@@ -419,6 +419,7 @@ int prompt( FILE *ptrMessageFile, int *previousChar, int commandChar )
             }
             break;
 
+         case 'P':
          case 'p':
             if ( *previousChar == -1 )
             {

--- a/edit.c
+++ b/edit.c
@@ -129,7 +129,7 @@ void makeMessage( int upload ) /* 0 = normal, 1 = upload (end w/^D) */
       }
       else if ( previousChar < 0 )
       {
-         inputChar = 'P';
+         inputChar = 'p';
       }
       else if ( tabcount )
       {
@@ -462,7 +462,6 @@ int prompt( FILE *ptrMessageFile, int *previousChar, int commandChar )
             }
             break;
 
-         case 'P':
          case 'p':
             if ( *previousChar == -1 )
             {

--- a/edit.c
+++ b/edit.c
@@ -12,6 +12,49 @@
 #include "defs.h"
 #include "ext.h"
 
+static void printEditorCommandPrompt( void )
+{
+   char aryAnsiSequence[32];
+   static const char *aryCommandLabels[] =
+      {
+         "Abort",
+         "Continue",
+         "Edit",
+         "Print",
+         "Save",
+         "Xpress" };
+   size_t itemIndex;
+
+   if ( !flagsConfiguration.useAnsi )
+   {
+      printf( "<A>bort <C>ontinue <E>dit <P>rint <S>ave <X>press -> " );
+      return;
+   }
+
+   for ( itemIndex = 0; itemIndex < sizeof( aryCommandLabels ) / sizeof( aryCommandLabels[0] ); itemIndex++ )
+   {
+      formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                    color.forum );
+      printf( "%s", aryAnsiSequence );
+      printf( "%c", aryCommandLabels[itemIndex][0] );
+
+      formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                    color.number );
+      printf( "%s", aryAnsiSequence );
+      printf( "%s", aryCommandLabels[itemIndex] + 1 );
+
+      if ( itemIndex + 1 < sizeof( aryCommandLabels ) / sizeof( aryCommandLabels[0] ) )
+      {
+         printf( "  " );
+      }
+   }
+
+   printf( " -> " );
+   formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                 color.text );
+   printf( "%s", aryAnsiSequence );
+}
+
 void makeMessage( int upload ) /* 0 = normal, 1 = upload (end w/^D) */
 {
    int inputChar;
@@ -358,7 +401,7 @@ int prompt( FILE *ptrMessageFile, int *previousChar, int commandChar )
             (void)inKey();
             if ( flagsConfiguration.useAnsi )
             {
-               colorize( "@YA@Cbort  @YC@Continue  @YE@Cdit  @YP@Crint  @YS@Cave  @YX@Cpress -> @G " );
+               printEditorCommandPrompt();
             }
             else
             {

--- a/ext.h
+++ b/ext.h
@@ -43,7 +43,7 @@ extern sigjmp_buf jumpEnv; /* Yuck!  I have to use longjmp!  Gag! */
 extern jmp_buf jumpEnv; /* Yuck!  I have to use longjmp!  Gag! */
 #endif
 
-extern char aryBbsHost[64];         /* name of bbs host (bbs.isca.uiowa.edu) */
+extern char aryBbsHost[64];         /* name of bbs host (bbs.iscabbs.com) */
 extern char aryCommandLineHost[64]; /* name of bbs host from command line */
 extern unsigned short bbsPort;      /* port to connect to (23 or 992) */
 extern unsigned short cmdLinePort;  /* port to connect to from command line */

--- a/getline.c
+++ b/getline.c
@@ -443,7 +443,8 @@ char *getName( int quitPriv )
                }
                *ptrCursor++ = (char)inputChar;
                putchar( inputChar );
-               if ( quitPriv == 2 || quitPriv == -999 )
+               if ( flagsConfiguration.shouldEnableNameAutocomplete &&
+                    ( quitPriv == 2 || quitPriv == -999 ) )
                {
                   if ( smartName( aryNameBuffer, ptrCursor ) )
                   {

--- a/getline.c
+++ b/getline.c
@@ -381,8 +381,8 @@ char *getName( int quitPriv )
             continue;
          }
          if ( inputChar == '\b' || inputChar == CTRL_X ||
-              inputChar == CTRL_W ||
-              inputChar == ' ' || isalpha( inputChar ) ||
+              inputChar == CTRL_W || inputChar == ' ' ||
+              isalpha( inputChar ) ||
               ( isdigit( inputChar ) && quitPriv == 3 ) )
          {
             invalid = 0;

--- a/getline.c
+++ b/getline.c
@@ -381,7 +381,7 @@ char *getName( int quitPriv )
             continue;
          }
          if ( inputChar == '\b' || inputChar == CTRL_X ||
-              inputChar == CTRL_W || inputChar == CTRL_R ||
+              inputChar == CTRL_W ||
               inputChar == ' ' || isalpha( inputChar ) ||
               ( isdigit( inputChar ) && quitPriv == 3 ) )
          {
@@ -390,12 +390,6 @@ char *getName( int quitPriv )
          else
          {
             handleInvalidInput( &invalid );
-            continue;
-         }
-         if ( inputChar == CTRL_R )
-         {
-            *ptrCursor = 0;
-            printf( "\r\n%s", aryNameBuffer );
             continue;
          }
          do
@@ -581,8 +575,7 @@ void getString( int length, char *result, int line )
          break;
       }
       if ( inputChar < ' ' && inputChar != '\b' &&
-           inputChar != CTRL_X && inputChar != CTRL_W &&
-           inputChar != CTRL_R )
+           inputChar != CTRL_X && inputChar != CTRL_W )
       {
          handleInvalidInput( &invalid );
          continue;
@@ -590,15 +583,6 @@ void getString( int length, char *result, int line )
       else
       {
          invalid = 0;
-      }
-      if ( inputChar == CTRL_R )
-      {
-         *ptrCursor = 0;
-         if ( !hidden )
-         {
-            printf( "\r\n%s", result );
-         }
-         continue;
       }
       if ( inputChar == '\b' || inputChar == CTRL_X )
       {

--- a/info.c
+++ b/info.c
@@ -328,14 +328,9 @@ void information( void )
 
    while ( true )
    {
-      if ( flagsConfiguration.useAnsi )
-      {
-         colorize( "\r\n@YC@Copyright  @YL@Cicense  @YW@Carranty  @YT@Cechnical  @YQ@Cuit\r\n@YClient information -> @G" );
-      }
-      else
-      {
-         stdPrintf( "\r\n<C>opyright <L>icense <W>arranty  <T>echnical <Q>uit\r\nClient information -> " );
-      }
+      printThemedMnemonicText( "\r\n<C>opyright  <L>icense  <W>arranty  <T>echnical  <Q>uit", color.number );
+      printThemedMnemonicText( "\r\nClient information -> ", color.forum );
+      printAnsiForegroundColorValue( color.text );
       int inputChar = readValidatedMenuKey( INFO_MENU_KEYS );
       switch ( inputChar )
       {

--- a/info.c
+++ b/info.c
@@ -30,29 +30,10 @@ void feedPager( int startrow, ... )
       currentRow++;
       if ( currentRow == rows )
       {
-         /* More prompt */
-         printf( "--MORE-- " );
-         fflush( stdout );
-         int inputChar;
-
-         inputChar = readFoldedKey();
-         switch ( inputChar )
+         if ( more( &currentRow, -1 ) < 0 )
          {
-            case 'n':
-            case 's':
-            case 'q':
-               printf( "\r        \r" );
-               va_end( ap );
-               return;
-               /* NOTREACHED */
-            case '\n':
-               currentRow--;
-               printf( "\r        \r" );
-               break;
-            default:
-               currentRow = 1;
-               printf( "\r        \r" );
-               break;
+            va_end( ap );
+            return;
          }
       }
    }

--- a/proto.h
+++ b/proto.h
@@ -31,6 +31,7 @@ extern void
    continuedPostHelper P( (void)),
    copyright P( (void)),
    deinitialize P( (void)),
+   defaultNameAutocompleteIfUnset P( (void)),
    defaultColors P( (int)),
    editUsers P( (slist *, int ( *findfn )( const void *, const void * ), const char *)),
    expressColorConfig P( (void)),

--- a/proto.h
+++ b/proto.h
@@ -21,6 +21,7 @@ extern void
    ansiTransformExpress P( (char *, size_t)),
    ansiTransformPostHeader P( (char *, size_t, int)),
    arguments P( (int, char **)),
+   brilliantColors P( (void)),
    configBbsRc P( (void)),
    colorConfig P( (void)),
    colorblindColors P( (void)),

--- a/proto.h
+++ b/proto.h
@@ -106,6 +106,8 @@ extern void
    techInfo P( (void)),
    telInit P( (void)),
    tempFileError P( (void)),
+   printAnsiForegroundColorValue P( (int)),
+   printThemedMnemonicText P( (const char *, int)),
    titleBar P( (void)),
    trimTrailingWhitespace P( (char *)),
    truncateBbsRc P( (long)),

--- a/proto.h
+++ b/proto.h
@@ -75,6 +75,7 @@ extern void
    postColorConfig P( (void)),
    postFriendColorConfig P( (void)),
    postUserColorConfig P( (void)),
+   promptForScreenReaderModeIfUnset P( (void)),
    readBbsRc P( (void)),
    replyCodeTransformExpress P( (char *, size_t)),
    replyMessage P( (void)),

--- a/test/test_bbsrc.c
+++ b/test/test_bbsrc.c
@@ -1346,6 +1346,58 @@ static void readBbsRc_WhenConfigUsesBrightAnsiColorNames_ParsesAnsi16Values( voi
    unlink( aryPath );
 }
 
+static void readBbsRc_WhenConfigUsesLongNamedColorLine_ParsesWithoutLineTooLongWarning( void **state )
+{
+   // Arrange
+   char aryPath[PATH_MAX];
+
+   (void)state;
+
+   cleanupReadState();
+   resetTracking();
+   if ( !tryCreateTempPath( aryPath, sizeof( aryPath ), "/tmp/iobbsrc_test_XXXXXX" ) )
+   {
+      fail_msg( "Arrange failed: unable to create temporary path for long named-color test" );
+      return;
+   }
+   if ( !tryWriteFileContents(
+           aryPath,
+           "color brightgreen brightyellow brightcyan brightred brightgreen brightblue brightmagenta brightmagenta brightcyan brightgreen brightmagenta brightred brightgreen brightyellow brightyellow brightwhite brightwhite 0 brightgreen brightcyan brightgreen brightgreen brightgreen brightgreen\n"
+           "version 2310\n" ) )
+   {
+      unlink( aryPath );
+      fail_msg( "Arrange failed: unable to write long named-color configuration content" );
+      return;
+   }
+   snprintf( aryBbsRcName, sizeof( aryBbsRcName ), "%s", aryPath );
+   snprintf( aryMyEditor, sizeof( aryMyEditor ), "%s", "nano" );
+   isLoginShell = 0;
+   isBbsRcReadOnly = 0;
+
+   // Act
+   readBbsRc();
+
+   // Assert
+   if ( strstr( aryStdPrintfLog, "too long" ) != NULL )
+   {
+      fail_msg( "long named color lines should not trigger a line-too-long warning; log was: %s",
+                aryStdPrintfLog );
+   }
+   if ( color.text != 10 || color.forum != 11 || color.number != 14 || color.errorTextColor != 9 )
+   {
+      fail_msg( "long named color parsing should still set general colors correctly; got text=%d forum=%d number=%d error=%d",
+                color.text, color.forum, color.number, color.errorTextColor );
+   }
+   if ( color.postdate != 13 || color.postname != 14 || color.posttext != 10 )
+   {
+      fail_msg( "long named color parsing should still set post colors; got date=%d name=%d text=%d",
+                color.postdate, color.postname, color.posttext );
+   }
+
+   cleanupReadState();
+   unlink( aryPath );
+}
+
 static void readBbsRc_WhenConfigUsesMixedNamedAndNumericColors_ParsesBothForms( void **state )
 {
    // Arrange
@@ -1452,6 +1504,7 @@ int main( void )
       cmocka_unit_test( readBbsRc_WhenConfigContainsInvalidColor_PrintsWarning ),
       cmocka_unit_test( readBbsRc_WhenConfigUsesNamedColors_ParsesExtendedPaletteValues ),
       cmocka_unit_test( readBbsRc_WhenConfigUsesBrightAnsiColorNames_ParsesAnsi16Values ),
+      cmocka_unit_test( readBbsRc_WhenConfigUsesLongNamedColorLine_ParsesWithoutLineTooLongWarning ),
       cmocka_unit_test( readBbsRc_WhenConfigUsesMixedNamedAndNumericColors_ParsesBothForms ),
       cmocka_unit_test( readBbsRc_WhenConfigFileMissing_CreatesFileAndUsesDefaults ),
    };

--- a/test/test_bbsrc.c
+++ b/test/test_bbsrc.c
@@ -21,6 +21,7 @@ static int setupVersionArg;
 static int perrorCallCount;
 static int writeBbsRcCallCount;
 static int promptForScreenReaderModeCallCount;
+static int defaultNameAutocompleteIfUnsetCallCount;
 static char aryLastPerrorMessage[128];
 static char aryLastPerrorHeading[64];
 static char aryStdPrintfLog[16384];
@@ -32,6 +33,7 @@ static void resetTracking( void )
    perrorCallCount = 0;
    writeBbsRcCallCount = 0;
    promptForScreenReaderModeCallCount = 0;
+   defaultNameAutocompleteIfUnsetCallCount = 0;
    aryLastPerrorMessage[0] = '\0';
    aryLastPerrorHeading[0] = '\0';
    aryStdPrintfLog[0] = '\0';
@@ -243,6 +245,14 @@ void promptForScreenReaderModeIfUnset( void )
    promptForScreenReaderModeCallCount++;
    flagsConfiguration.isScreenReaderModeEnabled = 0;
    flagsConfiguration.hasScreenReaderModeSetting = 1;
+}
+
+void defaultNameAutocompleteIfUnset( void )
+{
+   defaultNameAutocompleteIfUnsetCallCount++;
+   flagsConfiguration.shouldEnableNameAutocomplete =
+      (unsigned int)!flagsConfiguration.isScreenReaderModeEnabled;
+   flagsConfiguration.hasNameAutocompleteSetting = 1;
 }
 
 void sPerror( const char *message, const char *heading )
@@ -712,6 +722,51 @@ static void readBbsRc_WhenConfigSetsScreenReaderOne_EnablesScreenReaderMode( voi
    unlink( aryPath );
 }
 
+static void readBbsRc_WhenConfigSetsAutocompleteZero_DisablesAutocomplete( void **state )
+{
+   // Arrange
+   char aryPath[PATH_MAX];
+
+   (void)state;
+
+   cleanupReadState();
+   resetTracking();
+   if ( !tryCreateTempPath( aryPath, sizeof( aryPath ), "/tmp/iobbsrc_test_XXXXXX" ) )
+   {
+      fail_msg( "Arrange failed: unable to create temporary path for autocomplete=0 test" );
+      return;
+   }
+   if ( !tryWriteFileContents(
+           aryPath,
+           "autocomplete 0\n"
+           "version 2310\n" ) )
+   {
+      unlink( aryPath );
+      fail_msg( "Arrange failed: unable to write configuration content for autocomplete=0 test" );
+      return;
+   }
+   snprintf( aryBbsRcName, sizeof( aryBbsRcName ), "%s", aryPath );
+   snprintf( aryMyEditor, sizeof( aryMyEditor ), "%s", "nano" );
+   isLoginShell = 0;
+   isBbsRcReadOnly = 0;
+
+   // Act
+   readBbsRc();
+
+   // Assert
+   if ( flagsConfiguration.shouldEnableNameAutocomplete )
+   {
+      fail_msg( "autocomplete 0 should disable name autocomplete" );
+   }
+   if ( !flagsConfiguration.hasNameAutocompleteSetting )
+   {
+      fail_msg( "autocomplete 0 should mark the setting as present" );
+   }
+
+   cleanupReadState();
+   unlink( aryPath );
+}
+
 static void readBbsRc_WhenConfigMissingScreenReaderSetting_PromptsAndRewrites( void **state )
 {
    // Arrange
@@ -757,6 +812,74 @@ static void readBbsRc_WhenConfigMissingScreenReaderSetting_PromptsAndRewrites( v
    if ( !flagsConfiguration.hasScreenReaderModeSetting )
    {
       fail_msg( "prompt helper should mark the screen reader setting as present" );
+   }
+   if ( defaultNameAutocompleteIfUnsetCallCount != 1 )
+   {
+      fail_msg( "missing autocomplete setting should trigger one default helper call; got %d",
+                defaultNameAutocompleteIfUnsetCallCount );
+   }
+   if ( !flagsConfiguration.hasNameAutocompleteSetting )
+   {
+      fail_msg( "autocomplete default helper should mark the setting as present" );
+   }
+   if ( !flagsConfiguration.shouldEnableNameAutocomplete )
+   {
+      fail_msg( "autocomplete should default on when screen reader mode is disabled" );
+   }
+
+   cleanupReadState();
+   unlink( aryPath );
+}
+
+static void readBbsRc_WhenAutocompleteMissingAndScreenReaderEnabled_DefaultsAutocompleteOff( void **state )
+{
+   // Arrange
+   char aryPath[PATH_MAX];
+
+   (void)state;
+
+   cleanupReadState();
+   resetTracking();
+   if ( !tryCreateTempPath( aryPath, sizeof( aryPath ), "/tmp/iobbsrc_test_XXXXXX" ) )
+   {
+      fail_msg( "Arrange failed: unable to create temporary path for missing autocomplete test" );
+      return;
+   }
+   if ( !tryWriteFileContents(
+           aryPath,
+           "screenreader 1\n"
+           "version 2310\n" ) )
+   {
+      unlink( aryPath );
+      fail_msg( "Arrange failed: unable to write configuration content for missing autocomplete test" );
+      return;
+   }
+   snprintf( aryBbsRcName, sizeof( aryBbsRcName ), "%s", aryPath );
+   snprintf( aryMyEditor, sizeof( aryMyEditor ), "%s", "nano" );
+   isLoginShell = 0;
+   isBbsRcReadOnly = 0;
+
+   // Act
+   readBbsRc();
+
+   // Assert
+   if ( defaultNameAutocompleteIfUnsetCallCount != 1 )
+   {
+      fail_msg( "missing autocomplete setting should trigger one default helper call; got %d",
+                defaultNameAutocompleteIfUnsetCallCount );
+   }
+   if ( !flagsConfiguration.hasNameAutocompleteSetting )
+   {
+      fail_msg( "missing autocomplete setting should be marked present after defaulting" );
+   }
+   if ( flagsConfiguration.shouldEnableNameAutocomplete )
+   {
+      fail_msg( "autocomplete should default off when screen reader mode is enabled" );
+   }
+   if ( writeBbsRcCallCount != 1 )
+   {
+      fail_msg( "missing autocomplete setting should rewrite .bbsrc once; got %d",
+                writeBbsRcCallCount );
    }
 
    cleanupReadState();
@@ -1269,7 +1392,9 @@ int main( void )
       cmocka_unit_test( readBbsRc_WhenConfigContainsObsoleteBrowserSetting_RewritesAndWarns ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsKeepaliveZero_DisablesTcpKeepalive ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsScreenReaderOne_EnablesScreenReaderMode ),
+      cmocka_unit_test( readBbsRc_WhenConfigSetsAutocompleteZero_DisablesAutocomplete ),
       cmocka_unit_test( readBbsRc_WhenConfigMissingScreenReaderSetting_PromptsAndRewrites ),
+      cmocka_unit_test( readBbsRc_WhenAutocompleteMissingAndScreenReaderEnabled_DefaultsAutocompleteOff ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsClickableUrlsZero_DisablesClickableUrls ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsClickableUrlsOne_EnablesClickableUrls ),
       cmocka_unit_test( readBbsRc_WhenConfigContainsInvalidClickableUrlsDefinition_PrintsWarningAndKeepsDefault ),

--- a/test/test_bbsrc.c
+++ b/test/test_bbsrc.c
@@ -769,6 +769,51 @@ static void readBbsRc_WhenConfigSetsScreenReaderOne_EnablesScreenReaderMode( voi
    unlink( aryPath );
 }
 
+static void readBbsRc_WhenConfigSetsTitleBarZero_DisablesTitleBarUpdates( void **state )
+{
+   // Arrange
+   char aryPath[PATH_MAX];
+
+   (void)state;
+
+   cleanupReadState();
+   resetTracking();
+   if ( !tryCreateTempPath( aryPath, sizeof( aryPath ), "/tmp/iobbsrc_test_XXXXXX" ) )
+   {
+      fail_msg( "Arrange failed: unable to create temporary path for titlebar=0 test" );
+      return;
+   }
+   if ( !tryWriteFileContents(
+           aryPath,
+           "titlebar 0\n"
+           "version 2310\n" ) )
+   {
+      unlink( aryPath );
+      fail_msg( "Arrange failed: unable to write configuration content for titlebar=0 test" );
+      return;
+   }
+   snprintf( aryBbsRcName, sizeof( aryBbsRcName ), "%s", aryPath );
+   snprintf( aryMyEditor, sizeof( aryMyEditor ), "%s", "nano" );
+   isLoginShell = 0;
+   isBbsRcReadOnly = 0;
+
+   // Act
+   readBbsRc();
+
+   // Assert
+   if ( flagsConfiguration.shouldEnableTitleBar )
+   {
+      fail_msg( "titlebar 0 should disable terminal title updates" );
+   }
+   if ( !flagsConfiguration.hasTitleBarSetting )
+   {
+      fail_msg( "titlebar 0 should mark the title bar setting as present" );
+   }
+
+   cleanupReadState();
+   unlink( aryPath );
+}
+
 static void readBbsRc_WhenConfigSetsAutocompleteZero_DisablesAutocomplete( void **state )
 {
    // Arrange
@@ -1491,6 +1536,7 @@ int main( void )
       cmocka_unit_test( readBbsRc_WhenConfigContainsObsoleteBrowserSetting_RewritesAndWarns ),
       cmocka_unit_test( readBbsRc_WhenConfigUsesLegacyIscaIp_RewritesToCanonicalHostname ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsKeepaliveZero_DisablesTcpKeepalive ),
+      cmocka_unit_test( readBbsRc_WhenConfigSetsTitleBarZero_DisablesTitleBarUpdates ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsScreenReaderOne_EnablesScreenReaderMode ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsAutocompleteZero_DisablesAutocomplete ),
       cmocka_unit_test( readBbsRc_WhenConfigMissingScreenReaderSetting_PromptsAndRewrites ),

--- a/test/test_bbsrc.c
+++ b/test/test_bbsrc.c
@@ -20,6 +20,7 @@ static int setupCallCount;
 static int setupVersionArg;
 static int perrorCallCount;
 static int writeBbsRcCallCount;
+static int promptForScreenReaderModeCallCount;
 static char aryLastPerrorMessage[128];
 static char aryLastPerrorHeading[64];
 static char aryStdPrintfLog[16384];
@@ -30,6 +31,7 @@ static void resetTracking( void )
    setupVersionArg = 0;
    perrorCallCount = 0;
    writeBbsRcCallCount = 0;
+   promptForScreenReaderModeCallCount = 0;
    aryLastPerrorMessage[0] = '\0';
    aryLastPerrorHeading[0] = '\0';
    aryStdPrintfLog[0] = '\0';
@@ -234,6 +236,13 @@ void setup( int oldversion )
 void writeBbsRc( void )
 {
    writeBbsRcCallCount++;
+}
+
+void promptForScreenReaderModeIfUnset( void )
+{
+   promptForScreenReaderModeCallCount++;
+   flagsConfiguration.isScreenReaderModeEnabled = 0;
+   flagsConfiguration.hasScreenReaderModeSetting = 1;
 }
 
 void sPerror( const char *message, const char *heading )
@@ -647,6 +656,107 @@ static void readBbsRc_WhenConfigSetsKeepaliveZero_DisablesTcpKeepalive( void **s
    if ( flagsConfiguration.shouldUseTcpKeepalive )
    {
       fail_msg( "keepalive 0 should disable TCP keepalive" );
+   }
+
+   cleanupReadState();
+   unlink( aryPath );
+}
+
+static void readBbsRc_WhenConfigSetsScreenReaderOne_EnablesScreenReaderMode( void **state )
+{
+   // Arrange
+   char aryPath[PATH_MAX];
+
+   (void)state;
+
+   cleanupReadState();
+   resetTracking();
+   if ( !tryCreateTempPath( aryPath, sizeof( aryPath ), "/tmp/iobbsrc_test_XXXXXX" ) )
+   {
+      fail_msg( "Arrange failed: unable to create temporary path for screenreader=1 test" );
+      return;
+   }
+   if ( !tryWriteFileContents(
+           aryPath,
+           "screenreader 1\n"
+           "version 2310\n" ) )
+   {
+      unlink( aryPath );
+      fail_msg( "Arrange failed: unable to write configuration content for screenreader=1 test" );
+      return;
+   }
+   snprintf( aryBbsRcName, sizeof( aryBbsRcName ), "%s", aryPath );
+   snprintf( aryMyEditor, sizeof( aryMyEditor ), "%s", "nano" );
+   isLoginShell = 0;
+   isBbsRcReadOnly = 0;
+
+   // Act
+   readBbsRc();
+
+   // Assert
+   if ( !flagsConfiguration.isScreenReaderModeEnabled )
+   {
+      fail_msg( "screenreader 1 should enable screen reader mode" );
+   }
+   if ( !flagsConfiguration.hasScreenReaderModeSetting )
+   {
+      fail_msg( "screenreader 1 should mark the setting as present" );
+   }
+   if ( promptForScreenReaderModeCallCount != 0 )
+   {
+      fail_msg( "screenreader 1 should not trigger the missing-setting prompt helper; got %d calls",
+                promptForScreenReaderModeCallCount );
+   }
+
+   cleanupReadState();
+   unlink( aryPath );
+}
+
+static void readBbsRc_WhenConfigMissingScreenReaderSetting_PromptsAndRewrites( void **state )
+{
+   // Arrange
+   char aryPath[PATH_MAX];
+
+   (void)state;
+
+   cleanupReadState();
+   resetTracking();
+   if ( !tryCreateTempPath( aryPath, sizeof( aryPath ), "/tmp/iobbsrc_test_XXXXXX" ) )
+   {
+      fail_msg( "Arrange failed: unable to create temporary path for missing screenreader test" );
+      return;
+   }
+   if ( !tryWriteFileContents(
+           aryPath,
+           "keepalive 1\n"
+           "version 2310\n" ) )
+   {
+      unlink( aryPath );
+      fail_msg( "Arrange failed: unable to write configuration content for missing screenreader test" );
+      return;
+   }
+   snprintf( aryBbsRcName, sizeof( aryBbsRcName ), "%s", aryPath );
+   snprintf( aryMyEditor, sizeof( aryMyEditor ), "%s", "nano" );
+   isLoginShell = 0;
+   isBbsRcReadOnly = 0;
+
+   // Act
+   readBbsRc();
+
+   // Assert
+   if ( promptForScreenReaderModeCallCount != 1 )
+   {
+      fail_msg( "missing screenreader setting should trigger one prompt helper call; got %d",
+                promptForScreenReaderModeCallCount );
+   }
+   if ( writeBbsRcCallCount != 1 )
+   {
+      fail_msg( "missing screenreader setting should rewrite .bbsrc once; got %d",
+                writeBbsRcCallCount );
+   }
+   if ( !flagsConfiguration.hasScreenReaderModeSetting )
+   {
+      fail_msg( "prompt helper should mark the screen reader setting as present" );
    }
 
    cleanupReadState();
@@ -1158,6 +1268,8 @@ int main( void )
       cmocka_unit_test( readBbsRc_WhenConfigHasEntries_ParsesValuesAndIgnoresDuplicateEnemy ),
       cmocka_unit_test( readBbsRc_WhenConfigContainsObsoleteBrowserSetting_RewritesAndWarns ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsKeepaliveZero_DisablesTcpKeepalive ),
+      cmocka_unit_test( readBbsRc_WhenConfigSetsScreenReaderOne_EnablesScreenReaderMode ),
+      cmocka_unit_test( readBbsRc_WhenConfigMissingScreenReaderSetting_PromptsAndRewrites ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsClickableUrlsZero_DisablesClickableUrls ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsClickableUrlsOne_EnablesClickableUrls ),
       cmocka_unit_test( readBbsRc_WhenConfigContainsInvalidClickableUrlsDefinition_PrintsWarningAndKeepsDefault ),

--- a/test/test_bbsrc.c
+++ b/test/test_bbsrc.c
@@ -631,6 +631,53 @@ static void readBbsRc_WhenConfigContainsObsoleteBrowserSetting_RewritesAndWarns(
    unlink( aryPath );
 }
 
+static void readBbsRc_WhenConfigUsesLegacyIscaIp_RewritesToCanonicalHostname( void **state )
+{
+   char aryPath[PATH_MAX];
+   FILE *ptrConfig;
+
+   (void)state;
+
+   cleanupReadState();
+   resetTracking();
+   if ( !tryCreateTempPath( aryPath, sizeof( aryPath ), "/tmp/iobbsrc_test_XXXXXX" ) )
+   {
+      fail_msg( "Arrange failed: unable to create temporary path for legacy ISCA IP migration test" );
+      return;
+   }
+
+   ptrConfig = fopen( aryPath, "w" );
+   if ( ptrConfig == NULL )
+   {
+      fail_msg( "Arrange failed: unable to open temporary config file" );
+      unlink( aryPath );
+      return;
+   }
+   fputs( "site 206.217.131.27 23\n", ptrConfig );
+   fclose( ptrConfig );
+
+   snprintf( aryBbsRcName, sizeof( aryBbsRcName ), "%s", aryPath );
+   snprintf( aryMyEditor, sizeof( aryMyEditor ), "%s", "nano" );
+   isLoginShell = 0;
+   isBbsRcReadOnly = 0;
+
+   // Act
+   readBbsRc();
+
+   // Assert
+   if ( strcmp( aryBbsHost, BBS_HOSTNAME ) != 0 )
+   {
+      fail_msg( "legacy ISCA IP should migrate to %s; got %s", BBS_HOSTNAME, aryBbsHost );
+   }
+   if ( bbsPort != BBS_PORT_NUMBER )
+   {
+      fail_msg( "legacy ISCA IP should keep the default port; got %u", bbsPort );
+   }
+
+   cleanupReadState();
+   unlink( aryPath );
+}
+
 static void readBbsRc_WhenConfigSetsKeepaliveZero_DisablesTcpKeepalive( void **state )
 {
    // Arrange
@@ -1390,6 +1437,7 @@ int main( void )
       cmocka_unit_test( readBbsRc_WhenConfigIsEmpty_AppliesDefaults ),
       cmocka_unit_test( readBbsRc_WhenConfigHasEntries_ParsesValuesAndIgnoresDuplicateEnemy ),
       cmocka_unit_test( readBbsRc_WhenConfigContainsObsoleteBrowserSetting_RewritesAndWarns ),
+      cmocka_unit_test( readBbsRc_WhenConfigUsesLegacyIscaIp_RewritesToCanonicalHostname ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsKeepaliveZero_DisablesTcpKeepalive ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsScreenReaderOne_EnablesScreenReaderMode ),
       cmocka_unit_test( readBbsRc_WhenConfigSetsAutocompleteZero_DisablesAutocomplete ),

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -455,7 +455,7 @@ static void colorblindColors_WhenApplied_SetsAccessiblePalette( void **state )
    }
    if ( color.postdate != 75 || color.postfrienddate != 25 ||
         color.postname != 214 || color.postfriendname != 175 ||
-        color.input2 != 36 || color.moreprompt != 221 ||
+        color.input2 != 214 || color.moreprompt != 221 ||
         color.expressname != 214 || color.expressfriendname != 175 )
    {
       fail_msg( "colorblindColors should map post, input, and express roles onto the preset palette; got postdate=%d frienddate=%d postname=%d friendname=%d input2=%d moreprompt=%d expressname=%d expressfriendname=%d",

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -200,6 +200,13 @@ static void defaultColors_WhenClearAllApplied_SetsKnownDefaults( void **state )
    {
       fail_msg( "defaultColors(1) did not set post/express defaults as expected" );
    }
+   if ( color.ansiBlackTextColor != 2 || color.ansiBlueTextColor != 4 ||
+        color.ansiMagentaTextColor != 5 || color.ansiWhiteTextColor != 7 )
+   {
+      fail_msg( "defaultColors(1) did not set full ANSI fallback colors as expected; got black=%d blue=%d magenta=%d white=%d",
+                color.ansiBlackTextColor, color.ansiBlueTextColor,
+                color.ansiMagentaTextColor, color.ansiWhiteTextColor );
+   }
 }
 
 static void defaultColors_WhenClearAllDisabled_LeavesBackgroundUnchanged( void **state )
@@ -474,6 +481,13 @@ static void colorblindColors_WhenApplied_SetsAccessiblePalette( void **state )
                 color.postfriendname, color.input2, color.moreprompt,
                 color.expressname, color.expressfriendname );
    }
+   if ( color.ansiBlackTextColor != 146 || color.ansiBlueTextColor != 75 ||
+        color.ansiMagentaTextColor != 175 || color.ansiWhiteTextColor != 221 )
+   {
+      fail_msg( "colorblindColors should theme the full incoming ANSI palette; got black=%d blue=%d magenta=%d white=%d",
+                color.ansiBlackTextColor, color.ansiBlueTextColor,
+                color.ansiMagentaTextColor, color.ansiWhiteTextColor );
+   }
 }
 
 static void brilliantColors_WhenApplied_SetsBrightDefaultPalette( void **state )
@@ -512,6 +526,13 @@ static void brilliantColors_WhenApplied_SetsBrightDefaultPalette( void **state )
                 color.anonymous, color.moreprompt, color.input1, color.input2,
                 color.expresstext, color.expressname,
                 color.expressfriendname, color.expressfriendtext );
+   }
+   if ( color.ansiBlackTextColor != 10 || color.ansiBlueTextColor != 12 ||
+        color.ansiMagentaTextColor != 13 || color.ansiWhiteTextColor != 15 )
+   {
+      fail_msg( "brilliantColors should theme the full incoming ANSI palette; got black=%d blue=%d magenta=%d white=%d",
+                color.ansiBlackTextColor, color.ansiBlueTextColor,
+                color.ansiMagentaTextColor, color.ansiWhiteTextColor );
    }
 }
 
@@ -555,6 +576,42 @@ static void hotDogColors_WhenApplied_SetsClassicHotDogPalette( void **state )
                 color.postdate, color.postfrienddate, color.postname,
                 color.postfriendname, color.anonymous, color.moreprompt,
                 color.input1, color.expressname, color.expressfriendname );
+   }
+   if ( color.ansiBlackTextColor != 130 || color.ansiBlueTextColor != 214 ||
+        color.ansiMagentaTextColor != 130 || color.ansiWhiteTextColor != 220 )
+   {
+      fail_msg( "hotDogColors should eliminate stray gray and purple by theming the full incoming ANSI palette; got black=%d blue=%d magenta=%d white=%d",
+                color.ansiBlackTextColor, color.ansiBlueTextColor,
+                color.ansiMagentaTextColor, color.ansiWhiteTextColor );
+   }
+}
+
+static void ansiTransform_WhenHotDogPaletteApplied_UsesThemeColorsForAllAnsiDigits( void **state )
+{
+   int transformedBlack;
+   int transformedBlue;
+   int transformedMagenta;
+   int transformedWhite;
+
+   // Arrange
+   (void)state;
+
+   resetState();
+   hotDogColors();
+
+   // Act
+   transformedBlack = ansiTransform( '0' );
+   transformedBlue = ansiTransform( '4' );
+   transformedMagenta = ansiTransform( '5' );
+   transformedWhite = ansiTransform( '7' );
+
+   // Assert
+   if ( transformedBlack != 130 || transformedBlue != 214 ||
+        transformedMagenta != 130 || transformedWhite != 220 )
+   {
+      fail_msg( "ansiTransform should map all incoming ANSI digits through the active Hotdog stand palette; got black=%d blue=%d magenta=%d white=%d",
+                transformedBlack, transformedBlue, transformedMagenta,
+                transformedWhite );
    }
 }
 
@@ -759,6 +816,7 @@ int main( void )
       cmocka_unit_test( brilliantColors_WhenApplied_SetsBrightDefaultPalette ),
       cmocka_unit_test( colorblindColors_WhenApplied_SetsAccessiblePalette ),
       cmocka_unit_test( hotDogColors_WhenApplied_SetsClassicHotDogPalette ),
+      cmocka_unit_test( ansiTransform_WhenHotDogPaletteApplied_UsesThemeColorsForAllAnsiDigits ),
       cmocka_unit_test( ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes ),
       cmocka_unit_test( ansiTransformExpress_WhenAnsiDisabled_LeavesTextUnchanged ),
       cmocka_unit_test( ansiTransformPostHeader_WhenFriendPost_RewritesHeaderDigitsAndTracksColor ),

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -476,6 +476,45 @@ static void colorblindColors_WhenApplied_SetsAccessiblePalette( void **state )
    }
 }
 
+static void brilliantColors_WhenApplied_SetsBrightDefaultPalette( void **state )
+{
+   // Arrange
+   (void)state;
+
+   resetState();
+   memset( &color, 0, sizeof( color ) );
+
+   // Act
+   brilliantColors();
+
+   // Assert
+   if ( color.text != 10 || color.forum != 11 || color.number != 14 ||
+        color.errorTextColor != 9 )
+   {
+      fail_msg( "brilliantColors should set bright general colors; got text=%d forum=%d number=%d error=%d",
+                color.text, color.forum, color.number, color.errorTextColor );
+   }
+   if ( color.background != 0 )
+   {
+      fail_msg( "brilliantColors should keep a black background; got %d", color.background );
+   }
+   if ( color.postdate != 13 || color.postfrienddate != 13 ||
+        color.postname != 14 || color.postfriendname != 9 ||
+        color.posttext != 10 || color.postfriendtext != 10 ||
+        color.anonymous != 11 || color.moreprompt != 11 ||
+        color.input1 != 10 || color.input2 != 14 ||
+        color.expresstext != 10 || color.expressname != 10 ||
+        color.expressfriendname != 10 || color.expressfriendtext != 10 )
+   {
+      fail_msg( "brilliantColors should map the default roles onto bright ANSI values; got postdate=%d frienddate=%d postname=%d friendname=%d posttext=%d friendposttext=%d anonymous=%d moreprompt=%d input1=%d input2=%d expresstext=%d expressname=%d expressfriendname=%d expressfriendtext=%d",
+                color.postdate, color.postfrienddate, color.postname,
+                color.postfriendname, color.posttext, color.postfriendtext,
+                color.anonymous, color.moreprompt, color.input1, color.input2,
+                color.expresstext, color.expressname,
+                color.expressfriendname, color.expressfriendtext );
+   }
+}
+
 static void hotDogColors_WhenApplied_SetsClassicHotDogPalette( void **state )
 {
    // Arrange
@@ -717,6 +756,7 @@ int main( void )
       cmocka_unit_test( formatAnsiForegroundSequence_WhenBrightColorRequested_UsesBrightAnsiCode ),
       cmocka_unit_test( formatAnsiForegroundSequence_WhenExtendedColorRequested_Uses256ColorCode ),
       cmocka_unit_test( formatAnsiDisplayStateSequence_WhenDefaultBackgroundRequested_UsesCombinedSelectors ),
+      cmocka_unit_test( brilliantColors_WhenApplied_SetsBrightDefaultPalette ),
       cmocka_unit_test( colorblindColors_WhenApplied_SetsAccessiblePalette ),
       cmocka_unit_test( hotDogColors_WhenApplied_SetsClassicHotDogPalette ),
       cmocka_unit_test( ansiTransformExpress_WhenFriendSender_UsesFriendColorCodes ),

--- a/test/test_color.c
+++ b/test/test_color.c
@@ -81,6 +81,17 @@ int colorize( const char *ptrText )
    return 1;
 }
 
+void printAnsiForegroundColorValue( int colorValue )
+{
+   (void)colorValue;
+}
+
+void printThemedMnemonicText( const char *ptrText, int defaultColor )
+{
+   (void)ptrText;
+   (void)defaultColor;
+}
+
 int fSortCompareVoid( const void *ptrLeft, const void *ptrRight )
 {
    const friend *const *ptrLeftFriend;

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -745,9 +745,9 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
    color.forum = 11;
    color.number = 14;
    color.errorTextColor = 9;
-   color.reserved1 = 8;
-   color.reserved2 = 8;
-   color.reserved3 = 8;
+   color.ansiBlackTextColor = 8;
+   color.ansiBlueTextColor = 8;
+   color.ansiMagentaTextColor = 8;
    color.postdate = 13;
    color.postname = 12;
    color.posttext = 15;
@@ -756,7 +756,7 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
    color.postfriendtext = 11;
    color.anonymous = 12;
    color.moreprompt = 14;
-   color.reserved4 = 8;
+   color.ansiWhiteTextColor = 8;
    color.reserved5 = 8;
    color.background = COLOR_VALUE_DEFAULT;
    color.input1 = 15;
@@ -852,9 +852,9 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
    color.forum = 123;
    color.number = 14;
    color.errorTextColor = 9;
-   color.reserved1 = 8;
-   color.reserved2 = 8;
-   color.reserved3 = 8;
+   color.ansiBlackTextColor = 8;
+   color.ansiBlueTextColor = 8;
+   color.ansiMagentaTextColor = 8;
    color.postdate = 13;
    color.postname = 12;
    color.posttext = 15;
@@ -863,7 +863,7 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
    color.postfriendtext = 11;
    color.anonymous = 12;
    color.moreprompt = 14;
-   color.reserved4 = 8;
+   color.ansiWhiteTextColor = 8;
    color.reserved5 = 8;
    color.background = COLOR_VALUE_DEFAULT;
    color.input1 = 15;

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -121,6 +121,17 @@ int colorize( const char *ptrText )
    return 1;
 }
 
+void printAnsiForegroundColorValue( int colorValue )
+{
+   (void)colorValue;
+}
+
+void printThemedMnemonicText( const char *ptrText, int defaultColor )
+{
+   (void)ptrText;
+   (void)defaultColor;
+}
+
 int colorValueToLegacyDigit( int colorValue )
 {
    return colorValue + '0';

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -609,7 +609,7 @@ static void configBbsRc_WhenOptionsToggleScreenReaderMode_UpdatesFlags( void **s
 {
    // Arrange
    const int aryMenuKeys[] = { 'o', 'q' };
-   const int aryYesNoAnswers[] = { 1, 0, 1, 0 };
+   const int aryYesNoAnswers[] = { 1, 0, 1, 1, 0 };
 
    (void)state;
    resetState();
@@ -641,6 +641,8 @@ static void configBbsRc_WhenOptionsToggleScreenReaderMode_UpdatesFlags( void **s
    flagsConfiguration.useAnsi = 0;
    flagsConfiguration.shouldUseTcpKeepalive = 1;
    flagsConfiguration.shouldEnableClickableUrls = 1;
+   flagsConfiguration.shouldEnableTitleBar = 1;
+   flagsConfiguration.hasTitleBarSetting = 0;
    flagsConfiguration.isScreenReaderModeEnabled = 0;
    flagsConfiguration.hasScreenReaderModeSetting = 0;
    flagsConfiguration.shouldEnableNameAutocomplete = 1;
@@ -687,6 +689,13 @@ static void configBbsRc_WhenOptionsToggleScreenReaderMode_UpdatesFlags( void **s
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "configBbsRc should display the screen reader mode option in the Options menu" );
+      return;
+   }
+   if ( strstr( aryStdPrintfLog,
+                "Update terminal title bar? (Yes) -> " ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "configBbsRc should display the title bar option in the Options menu" );
       return;
    }
    if ( strstr( aryStdPrintfLog,
@@ -767,6 +776,7 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
    color.expressfriendname = 13;
    flagsConfiguration.shouldUseTcpKeepalive = true;
    flagsConfiguration.shouldEnableClickableUrls = true;
+   flagsConfiguration.shouldEnableTitleBar = true;
    flagsConfiguration.isScreenReaderModeEnabled = true;
    flagsConfiguration.shouldEnableNameAutocomplete = false;
 
@@ -790,6 +800,12 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "writeBbsRc should emit 'clickableurls 1' when clickable URLs are enabled; output was:\n%s", aryOutput );
+      return;
+   }
+   if ( strstr( aryOutput, "\ntitlebar 1\n" ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "writeBbsRc should emit 'titlebar 1' when title bar updates are enabled; output was:\n%s", aryOutput );
       return;
    }
    if ( strstr( aryOutput, "\nscreenreader 1\n" ) == NULL )
@@ -874,6 +890,7 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
    color.expressfriendname = 13;
    flagsConfiguration.shouldUseTcpKeepalive = false;
    flagsConfiguration.shouldEnableClickableUrls = false;
+   flagsConfiguration.shouldEnableTitleBar = false;
    flagsConfiguration.isScreenReaderModeEnabled = false;
    flagsConfiguration.shouldEnableNameAutocomplete = true;
 
@@ -897,6 +914,12 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "writeBbsRc should emit 'clickableurls 0' when clickable URLs are disabled; output was:\n%s", aryOutput );
+      return;
+   }
+   if ( strstr( aryOutput, "\ntitlebar 0\n" ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "writeBbsRc should emit 'titlebar 0' when title bar updates are disabled; output was:\n%s", aryOutput );
       return;
    }
    if ( strstr( aryOutput, "\nscreenreader 0\n" ) == NULL )

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -598,7 +598,7 @@ static void configBbsRc_WhenOptionsToggleScreenReaderMode_UpdatesFlags( void **s
 {
    // Arrange
    const int aryMenuKeys[] = { 'o', 'q' };
-   const int aryYesNoAnswers[] = { 0, 0, 1, 1, 1, 0 };
+   const int aryYesNoAnswers[] = { 1, 0, 1, 0 };
 
    (void)state;
    resetState();
@@ -654,10 +654,16 @@ static void configBbsRc_WhenOptionsToggleScreenReaderMode_UpdatesFlags( void **s
       fail_msg( "configBbsRc should mark screen reader mode as configured after toggling it" );
       return;
    }
+   if ( flagsConfiguration.shouldEnableClickableUrls )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "configBbsRc should seed clickable URL summaries to no when screen reader mode is enabled and the user accepts the default" );
+      return;
+   }
    if ( flagsConfiguration.shouldEnableNameAutocomplete )
    {
       cleanupWriteBbsRcFixture();
-      fail_msg( "configBbsRc should update the autocomplete option when the user answers no" );
+      fail_msg( "configBbsRc should seed autocomplete to no when screen reader mode is enabled and the user accepts the default" );
       return;
    }
    if ( !flagsConfiguration.hasNameAutocompleteSetting )
@@ -672,10 +678,24 @@ static void configBbsRc_WhenOptionsToggleScreenReaderMode_UpdatesFlags( void **s
       fail_msg( "configBbsRc should display the screen reader mode option in the Options menu" );
       return;
    }
+   if ( strstr( aryStdPrintfLog,
+                "Append OSC 8 URL summaries to posts & mail? (No) -> " ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "configBbsRc should show the screen reader default of No for clickable URL summaries after enabling screen reader mode" );
+      return;
+   }
    if ( strstr( aryStdPrintfLog, "Autocomplete username in recipient prompts?" ) == NULL )
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "configBbsRc should display the autocomplete option in the Options menu" );
+      return;
+   }
+   if ( strstr( aryStdPrintfLog,
+                "Autocomplete username in recipient prompts? (No) -> " ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "configBbsRc should show the screen reader default of No for autocomplete after enabling screen reader mode" );
       return;
    }
 

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -21,10 +21,15 @@ static int aryYesNoQueue[32];
 static size_t yesNoCount;
 static size_t yesNoIndex;
 
+static int aryPromptQueue[32];
+static size_t promptCount;
+static size_t promptIndex;
+
 static const char *aryStringQueue[32];
 static size_t stringCount;
 static size_t stringIndex;
 static int getStringCallCount;
+static int sPromptCallCount;
 
 static char aryStdPrintfLog[4096];
 
@@ -55,9 +60,12 @@ static void resetState( void )
    getKeyIndex = 0;
    yesNoCount = 0;
    yesNoIndex = 0;
+   promptCount = 0;
+   promptIndex = 0;
    stringCount = 0;
    stringIndex = 0;
    getStringCallCount = 0;
+   sPromptCallCount = 0;
    aryStdPrintfLog[0] = '\0';
 }
 
@@ -77,6 +85,15 @@ static void setYesNoSequence( const int *aryValues, size_t valueCount )
                               aryYesNoQueue,
                               sizeof( aryYesNoQueue ) / sizeof( aryYesNoQueue[0] ) );
    yesNoIndex = 0;
+}
+
+static void setPromptSequence( const int *aryValues, size_t valueCount )
+{
+   promptCount = copyIntArray( aryValues,
+                               valueCount,
+                               aryPromptQueue,
+                               sizeof( aryPromptQueue ) / sizeof( aryPromptQueue[0] ) );
+   promptIndex = 0;
 }
 
 static void setStringSequence( const char **aryValues, size_t valueCount )
@@ -296,8 +313,12 @@ int sPrompt( const char *message, const char *heading, int defaultAnswer )
 {
    (void)message;
    (void)heading;
-   (void)defaultAnswer;
-   return 0;
+   sPromptCallCount++;
+   if ( promptIndex < promptCount )
+   {
+      return aryPromptQueue[promptIndex++];
+   }
+   return defaultAnswer;
 }
 
 int stdPrintf( const char *format, ... )
@@ -349,6 +370,10 @@ int yesNo( void )
 
 int yesNoDefault( int defaultAnswer )
 {
+   if ( yesNoIndex < yesNoCount )
+   {
+      return aryYesNoQueue[yesNoIndex++];
+   }
    return defaultAnswer;
 }
 
@@ -497,6 +522,134 @@ static void newAwayMessage_WhenUserAcceptsChange_ReplacesWithEnteredLines( void 
    }
 }
 
+static void setup_WhenScreenReaderModeIsUnset_PromptsAndStoresAnswer( void **state )
+{
+   // Arrange
+   const int aryPromptAnswers[] = { 1, 0 };
+
+   (void)state;
+   resetState();
+
+   flagsConfiguration.hasScreenReaderModeSetting = 0;
+   flagsConfiguration.isScreenReaderModeEnabled = 0;
+   setPromptSequence( aryPromptAnswers, sizeof( aryPromptAnswers ) / sizeof( aryPromptAnswers[0] ) );
+
+   cleanupWriteBbsRcFixture();
+   ptrBbsRc = tmpfile();
+   friendList = slistCreate( 0, fSortCompareVoid );
+   enemyList = slistCreate( 0, sortCompareVoid );
+   if ( ptrBbsRc == NULL || friendList == NULL || enemyList == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "Arrange failed: unable to initialize setup fixture" );
+      return;
+   }
+
+   snprintf( aryEditor, sizeof( aryEditor ), "%s", "nano" );
+   snprintf( aryBbsHost, sizeof( aryBbsHost ), "%s", "bbs.example.net" );
+   bbsPort = 23;
+   commandKey = ESC;
+   quitKey = CTRL_D;
+   suspKey = CTRL_Z;
+   shellKey = '!';
+   captureKey = 'c';
+   awayKey = 'a';
+
+   // Act
+   setup( INT_VERSION );
+
+   // Assert
+   if ( !flagsConfiguration.hasScreenReaderModeSetting )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "setup should mark the screen reader mode setting as present after prompting" );
+      return;
+   }
+   if ( !flagsConfiguration.isScreenReaderModeEnabled )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "setup should store the user's screen reader mode choice when they answer yes" );
+      return;
+   }
+   if ( sPromptCallCount < 2 )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "setup should prompt for screen reader mode before asking about advanced options; got %d prompts",
+                sPromptCallCount );
+      return;
+   }
+
+   cleanupWriteBbsRcFixture();
+}
+
+static void configBbsRc_WhenOptionsToggleScreenReaderMode_UpdatesFlags( void **state )
+{
+   // Arrange
+   const int aryMenuKeys[] = { 'o', 'q' };
+   const int aryYesNoAnswers[] = { 0, 0, 1, 1, 1 };
+
+   (void)state;
+   resetState();
+
+   cleanupWriteBbsRcFixture();
+   ptrBbsRc = tmpfile();
+   friendList = slistCreate( 0, fSortCompareVoid );
+   enemyList = slistCreate( 0, sortCompareVoid );
+   if ( ptrBbsRc == NULL || friendList == NULL || enemyList == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "Arrange failed: unable to initialize configBbsRc fixture" );
+      return;
+   }
+
+   snprintf( aryEditor, sizeof( aryEditor ), "%s", "nano" );
+   snprintf( aryBbsHost, sizeof( aryBbsHost ), "%s", "bbs.example.net" );
+   bbsPort = 23;
+   commandKey = ESC;
+   quitKey = CTRL_D;
+   suspKey = CTRL_Z;
+   shellKey = '!';
+   captureKey = 'c';
+   awayKey = 'a';
+   browserKey = 'w';
+   rows = 24;
+   isLoginShell = 0;
+   isBbsRcReadOnly = 0;
+   flagsConfiguration.useAnsi = 0;
+   flagsConfiguration.shouldUseTcpKeepalive = 1;
+   flagsConfiguration.shouldEnableClickableUrls = 1;
+   flagsConfiguration.isScreenReaderModeEnabled = 0;
+   flagsConfiguration.hasScreenReaderModeSetting = 0;
+
+   setGetKeySequence( aryMenuKeys, sizeof( aryMenuKeys ) / sizeof( aryMenuKeys[0] ) );
+   setYesNoSequence( aryYesNoAnswers, sizeof( aryYesNoAnswers ) / sizeof( aryYesNoAnswers[0] ) );
+
+   // Act
+   configBbsRc();
+
+   // Assert
+   if ( !flagsConfiguration.isScreenReaderModeEnabled )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "configBbsRc should enable screen reader mode when the option is answered yes" );
+      return;
+   }
+   if ( !flagsConfiguration.hasScreenReaderModeSetting )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "configBbsRc should mark screen reader mode as configured after toggling it" );
+      return;
+   }
+   if ( strstr( aryStdPrintfLog, "Use screen reader friendly mode?" ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "configBbsRc should display the screen reader mode option in the Options menu" );
+      return;
+   }
+
+   cleanupWriteBbsRcFixture();
+}
+
 static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state )
 {
    // Arrange
@@ -551,6 +704,7 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
    color.expressfriendname = 13;
    flagsConfiguration.shouldUseTcpKeepalive = true;
    flagsConfiguration.shouldEnableClickableUrls = true;
+   flagsConfiguration.isScreenReaderModeEnabled = true;
 
    // Act
    writeBbsRc();
@@ -572,6 +726,12 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "writeBbsRc should emit 'clickableurls 1' when clickable URLs are enabled; output was:\n%s", aryOutput );
+      return;
+   }
+   if ( strstr( aryOutput, "\nscreenreader 1\n" ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "writeBbsRc should emit 'screenreader 1' when screen reader mode is enabled; output was:\n%s", aryOutput );
       return;
    }
    if ( strstr( aryOutput, "\ncolor brightgreen brightyellow brightcyan brightred brightblack brightblack brightblack brightmagenta brightblue brightwhite brightred brightgreen brightyellow brightblue brightcyan brightblack brightblack default brightwhite brightgreen brightyellow brightmagenta brightcyan brightmagenta\n" ) == NULL )
@@ -644,6 +804,7 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
    color.expressfriendname = 13;
    flagsConfiguration.shouldUseTcpKeepalive = false;
    flagsConfiguration.shouldEnableClickableUrls = false;
+   flagsConfiguration.isScreenReaderModeEnabled = false;
 
    // Act
    writeBbsRc();
@@ -665,6 +826,12 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "writeBbsRc should emit 'clickableurls 0' when clickable URLs are disabled; output was:\n%s", aryOutput );
+      return;
+   }
+   if ( strstr( aryOutput, "\nscreenreader 0\n" ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "writeBbsRc should emit 'screenreader 0' when screen reader mode is disabled; output was:\n%s", aryOutput );
       return;
    }
    if ( strstr( aryOutput, "\ncolor brightgreen 123 brightcyan brightred brightblack brightblack brightblack brightmagenta brightblue brightwhite brightred brightgreen brightyellow brightblue brightcyan brightblack brightblack default brightwhite brightgreen brightyellow brightmagenta brightcyan brightmagenta\n" ) == NULL )
@@ -692,6 +859,8 @@ int main( void )
       cmocka_unit_test( newKey_WhenUserEntersSpace_ReturnsOldKey ),
       cmocka_unit_test( newAwayMessage_WhenUserDeclinesChange_PreservesExistingMessage ),
       cmocka_unit_test( newAwayMessage_WhenUserAcceptsChange_ReplacesWithEnteredLines ),
+      cmocka_unit_test( setup_WhenScreenReaderModeIsUnset_PromptsAndStoresAnswer ),
+      cmocka_unit_test( configBbsRc_WhenOptionsToggleScreenReaderMode_UpdatesFlags ),
       cmocka_unit_test( writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne ),
       cmocka_unit_test( writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero ),
    };

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -571,6 +571,18 @@ static void setup_WhenScreenReaderModeIsUnset_PromptsAndStoresAnswer( void **sta
       fail_msg( "setup should store the user's screen reader mode choice when they answer yes" );
       return;
    }
+   if ( !flagsConfiguration.hasNameAutocompleteSetting )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "setup should mark the autocomplete setting as present after choosing a screen reader mode" );
+      return;
+   }
+   if ( flagsConfiguration.shouldEnableNameAutocomplete )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "setup should default autocomplete off when screen reader mode is enabled" );
+      return;
+   }
    if ( sPromptCallCount < 2 )
    {
       cleanupWriteBbsRcFixture();
@@ -586,7 +598,7 @@ static void configBbsRc_WhenOptionsToggleScreenReaderMode_UpdatesFlags( void **s
 {
    // Arrange
    const int aryMenuKeys[] = { 'o', 'q' };
-   const int aryYesNoAnswers[] = { 0, 0, 1, 1, 1 };
+   const int aryYesNoAnswers[] = { 0, 0, 1, 1, 1, 0 };
 
    (void)state;
    resetState();
@@ -620,6 +632,8 @@ static void configBbsRc_WhenOptionsToggleScreenReaderMode_UpdatesFlags( void **s
    flagsConfiguration.shouldEnableClickableUrls = 1;
    flagsConfiguration.isScreenReaderModeEnabled = 0;
    flagsConfiguration.hasScreenReaderModeSetting = 0;
+   flagsConfiguration.shouldEnableNameAutocomplete = 1;
+   flagsConfiguration.hasNameAutocompleteSetting = 0;
 
    setGetKeySequence( aryMenuKeys, sizeof( aryMenuKeys ) / sizeof( aryMenuKeys[0] ) );
    setYesNoSequence( aryYesNoAnswers, sizeof( aryYesNoAnswers ) / sizeof( aryYesNoAnswers[0] ) );
@@ -640,10 +654,28 @@ static void configBbsRc_WhenOptionsToggleScreenReaderMode_UpdatesFlags( void **s
       fail_msg( "configBbsRc should mark screen reader mode as configured after toggling it" );
       return;
    }
+   if ( flagsConfiguration.shouldEnableNameAutocomplete )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "configBbsRc should update the autocomplete option when the user answers no" );
+      return;
+   }
+   if ( !flagsConfiguration.hasNameAutocompleteSetting )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "configBbsRc should mark autocomplete as configured after toggling it" );
+      return;
+   }
    if ( strstr( aryStdPrintfLog, "Use screen reader friendly mode?" ) == NULL )
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "configBbsRc should display the screen reader mode option in the Options menu" );
+      return;
+   }
+   if ( strstr( aryStdPrintfLog, "Autocomplete username in recipient prompts?" ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "configBbsRc should display the autocomplete option in the Options menu" );
       return;
    }
 
@@ -705,6 +737,7 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
    flagsConfiguration.shouldUseTcpKeepalive = true;
    flagsConfiguration.shouldEnableClickableUrls = true;
    flagsConfiguration.isScreenReaderModeEnabled = true;
+   flagsConfiguration.shouldEnableNameAutocomplete = false;
 
    // Act
    writeBbsRc();
@@ -732,6 +765,12 @@ static void writeBbsRc_WhenTcpKeepaliveEnabled_WritesKeepaliveOne( void **state 
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "writeBbsRc should emit 'screenreader 1' when screen reader mode is enabled; output was:\n%s", aryOutput );
+      return;
+   }
+   if ( strstr( aryOutput, "\nautocomplete 0\n" ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "writeBbsRc should emit 'autocomplete 0' when autocomplete is disabled; output was:\n%s", aryOutput );
       return;
    }
    if ( strstr( aryOutput, "\ncolor brightgreen brightyellow brightcyan brightred brightblack brightblack brightblack brightmagenta brightblue brightwhite brightred brightgreen brightyellow brightblue brightcyan brightblack brightblack default brightwhite brightgreen brightyellow brightmagenta brightcyan brightmagenta\n" ) == NULL )
@@ -805,6 +844,7 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
    flagsConfiguration.shouldUseTcpKeepalive = false;
    flagsConfiguration.shouldEnableClickableUrls = false;
    flagsConfiguration.isScreenReaderModeEnabled = false;
+   flagsConfiguration.shouldEnableNameAutocomplete = true;
 
    // Act
    writeBbsRc();
@@ -832,6 +872,12 @@ static void writeBbsRc_WhenTcpKeepaliveDisabled_WritesKeepaliveZero( void **stat
    {
       cleanupWriteBbsRcFixture();
       fail_msg( "writeBbsRc should emit 'screenreader 0' when screen reader mode is disabled; output was:\n%s", aryOutput );
+      return;
+   }
+   if ( strstr( aryOutput, "\nautocomplete 1\n" ) == NULL )
+   {
+      cleanupWriteBbsRcFixture();
+      fail_msg( "writeBbsRc should emit 'autocomplete 1' when autocomplete is enabled; output was:\n%s", aryOutput );
       return;
    }
    if ( strstr( aryOutput, "\ncolor brightgreen 123 brightcyan brightred brightblack brightblack brightblack brightmagenta brightblue brightwhite brightred brightgreen brightyellow brightblue brightcyan brightblack brightblack default brightwhite brightgreen brightyellow brightmagenta brightcyan brightmagenta\n" ) == NULL )

--- a/test/test_edit.c
+++ b/test/test_edit.c
@@ -384,7 +384,7 @@ static void prompt_WhenSaveSelected_SavesMessageAndReturnsMinusOne( void **state
    fclose( ptrMessageFile );
 }
 
-static void prompt_WhenInvokedWithUppercasePrint_LoadsExistingMessage( void **state )
+static void prompt_WhenInvokedWithPrintCommand_LoadsExistingMessage( void **state )
 {
    // Arrange
    FILE *ptrMessageFile;
@@ -398,14 +398,14 @@ static void prompt_WhenInvokedWithUppercasePrint_LoadsExistingMessage( void **st
    ptrMessageFile = tmpfile();
    if ( ptrMessageFile == NULL )
    {
-      fail_msg( "tmpfile failed in prompt uppercase print test setup" );
+      fail_msg( "tmpfile failed in prompt print test setup" );
       return;
    }
    fprintf( ptrMessageFile, "Existing draft line\n" );
    fflush( ptrMessageFile );
 
    // Act
-   result = prompt( ptrMessageFile, &previousChar, 'P' );
+   result = prompt( ptrMessageFile, &previousChar, 'p' );
 
    // Assert
    if ( result != 0 )
@@ -423,13 +423,13 @@ static void prompt_WhenInvokedWithUppercasePrint_LoadsExistingMessage( void **st
    if ( fseek( ptrMessageFile, 0L, SEEK_END ) != 0 )
    {
       fclose( ptrMessageFile );
-      fail_msg( "Arrange failed: unable to seek to end of message file after uppercase print path" );
+      fail_msg( "Arrange failed: unable to seek to end of message file after print path" );
       return;
    }
    if ( ftell( ptrMessageFile ) <= 0 )
    {
       fclose( ptrMessageFile );
-      fail_msg( "prompt uppercase print path should preserve existing draft contents" );
+      fail_msg( "prompt print path should preserve existing draft contents" );
       return;
    }
 
@@ -445,7 +445,7 @@ int main( void )
       cmocka_unit_test( checkFile_WhenTabExpansionPushesPast79_ReturnsOne ),
       cmocka_unit_test( checkFile_WhenTotalMessageSizeExceedsLimit_ReturnsOne ),
       cmocka_unit_test( prompt_WhenSaveSelected_SavesMessageAndReturnsMinusOne ),
-      cmocka_unit_test( prompt_WhenInvokedWithUppercasePrint_LoadsExistingMessage ),
+      cmocka_unit_test( prompt_WhenInvokedWithPrintCommand_LoadsExistingMessage ),
    };
 
    return cmocka_run_group_tests( aryTests, NULL, NULL );

--- a/test/test_edit.c
+++ b/test/test_edit.c
@@ -13,6 +13,28 @@
 #include "proto.h"
 #include "test_helpers.h"
 
+static int aryInputQueue[16];
+static size_t inputCount;
+static size_t inputIndex;
+static int arySentChars[512];
+static size_t sentCharCount;
+
+static void resetState( void )
+{
+   inputCount = 0;
+   inputIndex = 0;
+   sentCharCount = 0;
+   flagsConfiguration.isLastSave = 0;
+   flagsConfiguration.isPosting = 0;
+}
+
+static void setInputSequence( const int *aryKeys, size_t count )
+{
+   inputCount = copyIntArray( aryKeys, count, aryInputQueue,
+                              sizeof( aryInputQueue ) / sizeof( aryInputQueue[0] ) );
+   inputIndex = 0;
+}
+
 /* edit.c dependencies outside checkFile() scope for these tests. */
 int colorize( const char *ptrText )
 {
@@ -57,6 +79,10 @@ void getString( int length, char *result, int line )
 
 int inKey( void )
 {
+   if ( inputIndex < inputCount )
+   {
+      return aryInputQueue[inputIndex++];
+   }
    return '\n';
 }
 
@@ -95,6 +121,10 @@ int netPutChar( int inputChar )
 
 void sendTrackedChar( int inputChar )
 {
+   if ( sentCharCount < sizeof( arySentChars ) / sizeof( arySentChars[0] ) )
+   {
+      arySentChars[sentCharCount++] = inputChar;
+   }
    netPutChar( inputChar );
    byte++;
 }
@@ -126,6 +156,8 @@ static void checkFile_WhenMessageIsValid_ReturnsZero( void **state )
 
    (void)state;
 
+   resetState();
+
    ptrMessageFile = tmpfile();
    if ( ptrMessageFile == NULL )
    {
@@ -154,6 +186,8 @@ static void checkFile_WhenLineExceeds79Chars_ReturnsOne( void **state )
    int result;
 
    (void)state;
+
+   resetState();
 
    ptrMessageFile = tmpfile();
    if ( ptrMessageFile == NULL )
@@ -190,6 +224,8 @@ static void checkFile_WhenIllegalControlCharacterPresent_ReturnsOne( void **stat
 
    (void)state;
 
+   resetState();
+
    ptrMessageFile = tmpfile();
    if ( ptrMessageFile == NULL )
    {
@@ -221,6 +257,8 @@ static void checkFile_WhenTabExpansionPushesPast79_ReturnsOne( void **state )
    int result;
 
    (void)state;
+
+   resetState();
 
    ptrMessageFile = tmpfile();
    if ( ptrMessageFile == NULL )
@@ -259,6 +297,8 @@ static void checkFile_WhenTotalMessageSizeExceedsLimit_ReturnsOne( void **state 
 
    (void)state;
 
+   resetState();
+
    ptrMessageFile = tmpfile();
    if ( ptrMessageFile == NULL )
    {
@@ -289,6 +329,113 @@ static void checkFile_WhenTotalMessageSizeExceedsLimit_ReturnsOne( void **state 
    fclose( ptrMessageFile );
 }
 
+static void prompt_WhenSaveSelected_SavesMessageAndReturnsMinusOne( void **state )
+{
+   // Arrange
+   FILE *ptrMessageFile;
+   int result;
+   int previousChar;
+   int aryKeys[] = { '\n', 's' };
+
+   (void)state;
+
+   resetState();
+   setInputSequence( aryKeys, sizeof( aryKeys ) / sizeof( aryKeys[0] ) );
+   flagsConfiguration.isPosting = 1;
+   previousChar = 0;
+   ptrMessageFile = tmpfile();
+   if ( ptrMessageFile == NULL )
+   {
+      fail_msg( "tmpfile failed in prompt save test setup" );
+      return;
+   }
+   fprintf( ptrMessageFile, "Breaking News\n" );
+   fflush( ptrMessageFile );
+
+   // Act
+   result = prompt( ptrMessageFile, &previousChar, '\n' );
+
+   // Assert
+   if ( result != -1 )
+   {
+      fclose( ptrMessageFile );
+      fail_msg( "prompt should return -1 after saving a valid message; got %d", result );
+      return;
+   }
+   if ( !flagsConfiguration.isLastSave || flagsConfiguration.isPosting )
+   {
+      fclose( ptrMessageFile );
+      fail_msg( "prompt should mark the post saved and clear posting state; got isLastSave=%u isPosting=%u",
+                flagsConfiguration.isLastSave, flagsConfiguration.isPosting );
+      return;
+   }
+   if ( sentCharCount < 3 ||
+        arySentChars[sentCharCount - 2] != CTRL_D ||
+        arySentChars[sentCharCount - 1] != 's' )
+   {
+      fclose( ptrMessageFile );
+      fail_msg( "prompt save path should send CTRL_D followed by 's'; sent count=%zu last=%d second_last=%d",
+                sentCharCount,
+                sentCharCount > 0 ? arySentChars[sentCharCount - 1] : -1,
+                sentCharCount > 1 ? arySentChars[sentCharCount - 2] : -1 );
+      return;
+   }
+
+   fclose( ptrMessageFile );
+}
+
+static void prompt_WhenInvokedWithUppercasePrint_LoadsExistingMessage( void **state )
+{
+   // Arrange
+   FILE *ptrMessageFile;
+   int result;
+   int previousChar;
+
+   (void)state;
+
+   resetState();
+   previousChar = -1;
+   ptrMessageFile = tmpfile();
+   if ( ptrMessageFile == NULL )
+   {
+      fail_msg( "tmpfile failed in prompt uppercase print test setup" );
+      return;
+   }
+   fprintf( ptrMessageFile, "Existing draft line\n" );
+   fflush( ptrMessageFile );
+
+   // Act
+   result = prompt( ptrMessageFile, &previousChar, 'P' );
+
+   // Assert
+   if ( result != 0 )
+   {
+      fclose( ptrMessageFile );
+      fail_msg( "prompt should return 0 when reloading an existing draft; got %d", result );
+      return;
+   }
+   if ( previousChar != '\n' )
+   {
+      fclose( ptrMessageFile );
+      fail_msg( "prompt should change previousChar from -1 to newline after reloading an existing draft; got %d", previousChar );
+      return;
+   }
+   if ( fseek( ptrMessageFile, 0L, SEEK_END ) != 0 )
+   {
+      fclose( ptrMessageFile );
+      fail_msg( "Arrange failed: unable to seek to end of message file after uppercase print path" );
+      return;
+   }
+   if ( ftell( ptrMessageFile ) <= 0 )
+   {
+      fclose( ptrMessageFile );
+      fail_msg( "prompt uppercase print path should preserve existing draft contents" );
+      return;
+   }
+
+   fclose( ptrMessageFile );
+}
+
 int main( void )
 {
    const struct CMUnitTest aryTests[] = {
@@ -297,6 +444,8 @@ int main( void )
       cmocka_unit_test( checkFile_WhenIllegalControlCharacterPresent_ReturnsOne ),
       cmocka_unit_test( checkFile_WhenTabExpansionPushesPast79_ReturnsOne ),
       cmocka_unit_test( checkFile_WhenTotalMessageSizeExceedsLimit_ReturnsOne ),
+      cmocka_unit_test( prompt_WhenSaveSelected_SavesMessageAndReturnsMinusOne ),
+      cmocka_unit_test( prompt_WhenInvokedWithUppercasePrint_LoadsExistingMessage ),
    };
 
    return cmocka_run_group_tests( aryTests, NULL, NULL );

--- a/test/test_filter.c
+++ b/test/test_filter.c
@@ -38,6 +38,7 @@ static void resetState( void )
    flagsConfiguration.shouldDisableBold = 0;
    flagsConfiguration.useBold = 0;
    flagsConfiguration.shouldEnableClickableUrls = 1;
+   flagsConfiguration.isScreenReaderModeEnabled = 0;
 
    aryExpressMessageBuffer[0] = '\0';
    ptrExpressMessageBuffer = aryExpressMessageBuffer;
@@ -632,6 +633,31 @@ static void printWithOsc8Links_WhenClickableUrlsDisabled_PrintsPlainText( void *
    }
 }
 
+static void printWithOsc8Links_WhenScreenReaderModeEnabled_PrintsPlainText( void **state )
+{
+   // Arrange
+   const char *ptrMessage;
+
+   (void)state;
+
+   resetState();
+   flagsConfiguration.isScreenReaderModeEnabled = 1;
+   ptrMessage = "Read this https://example.dev/path";
+
+   // Act
+   printWithOsc8Links( ptrMessage );
+
+   // Assert
+   if ( strstr( aryPrintLog, "\033]8;;" ) != NULL )
+   {
+      fail_msg( "OSC-8 escapes should not be emitted when screen reader mode is enabled; log was: %s", aryPrintLog );
+   }
+   if ( strstr( aryPrintLog, ptrMessage ) == NULL )
+   {
+      fail_msg( "plain message text should be printed when screen reader mode is enabled; log was: %s", aryPrintLog );
+   }
+}
+
 static void emitUrlDetectionReport_WhenUrlsCollected_PrintsClickableSummary( void **state )
 {
    // Arrange
@@ -742,6 +768,39 @@ static void emitUrlDetectionReport_WhenClickableUrlsDisabled_EmitsNoSummary( voi
    resetLists();
 }
 
+static void emitUrlDetectionReport_WhenScreenReaderModeEnabled_EmitsNoSummary( void **state )
+{
+   // Arrange
+   (void)state;
+
+   resetState();
+   resetLists();
+   flagsConfiguration.isScreenReaderModeEnabled = 1;
+   urlQueue = newQueue( 1024, 5 );
+   if ( urlQueue == NULL )
+   {
+      fail_msg( "newQueue failed for screen reader URL detection report test setup" );
+   }
+
+   beginUrlDetectionReport();
+   filterUrl( "Read this https://example.dev/alpha" );
+
+   // Act
+   emitUrlDetectionReport();
+
+   // Assert
+   if ( strstr( aryPrintLog, "[Clickable URL(s) detected by BBS client]" ) != NULL )
+   {
+      fail_msg( "URL detection report should be suppressed when screen reader mode is enabled; log was: %s", aryPrintLog );
+   }
+   if ( strstr( aryPrintLog, "\033]8;;" ) != NULL )
+   {
+      fail_msg( "OSC-8 escapes should not be emitted in screen reader mode; log was: %s", aryPrintLog );
+   }
+
+   resetLists();
+}
+
 static void filterData_WhenAnsiColorMapsToBrightValue_EmitsFullAnsiSequence( void **state )
 {
    // Arrange
@@ -824,9 +883,11 @@ int main( void )
       cmocka_unit_test( printWithOsc8Links_WhenTextContainsHttpsUrl_EmitsHyperlinkEscapes ),
       cmocka_unit_test( printWithOsc8Links_WhenTextContainsWwwUrl_UsesHttpsTarget ),
       cmocka_unit_test( printWithOsc8Links_WhenClickableUrlsDisabled_PrintsPlainText ),
+      cmocka_unit_test( printWithOsc8Links_WhenScreenReaderModeEnabled_PrintsPlainText ),
       cmocka_unit_test( emitUrlDetectionReport_WhenUrlsCollected_PrintsClickableSummary ),
       cmocka_unit_test( emitUrlDetectionReport_WhenAnsiEnabled_UsesConfiguredColorState ),
       cmocka_unit_test( emitUrlDetectionReport_WhenClickableUrlsDisabled_EmitsNoSummary ),
+      cmocka_unit_test( emitUrlDetectionReport_WhenScreenReaderModeEnabled_EmitsNoSummary ),
       cmocka_unit_test( filterData_WhenAnsiColorMapsToBrightValue_EmitsFullAnsiSequence ),
       cmocka_unit_test( filterExpress_WhenAwayAndIncomingNewMessage_QueuesSender ),
    };

--- a/test/test_getline.c
+++ b/test/test_getline.c
@@ -339,6 +339,27 @@ static void getString_WhenRepeatedInvalidControlInputReceived_FlushesInput( void
    }
 }
 
+static void getString_WhenCtrlRReceived_IgnoresItAsInvalidInput( void **state )
+{
+   // Arrange
+   char aryResult[64];
+   const int aryKeys[] = { 'A', CTRL_R, 'B', '\n' };
+
+   (void)state;
+
+   resetTracking();
+   setInputSequence( aryKeys, sizeof( aryKeys ) / sizeof( aryKeys[0] ) );
+
+   // Act
+   getString( 20, aryResult, 0 );
+
+   // Assert
+   if ( strcmp( aryResult, "AB" ) != 0 )
+   {
+      fail_msg( "getString should ignore CTRL_R and keep surrounding text; got '%s'", aryResult );
+   }
+}
+
 static void getName_WhenAutocompleteEnabled_ExpandsUniqueName( void **state )
 {
    // Arrange
@@ -402,6 +423,7 @@ int main( void )
       cmocka_unit_test( getString_WhenCtrlWUsed_RemovesPreviousWord ),
       cmocka_unit_test( getString_WhenHiddenInputUsed_CapturesDotsInsteadOfPlainText ),
       cmocka_unit_test( getString_WhenRepeatedInvalidControlInputReceived_FlushesInput ),
+      cmocka_unit_test( getString_WhenCtrlRReceived_IgnoresItAsInvalidInput ),
       cmocka_unit_test( getName_WhenAutocompleteEnabled_ExpandsUniqueName ),
       cmocka_unit_test( getName_WhenAutocompleteDisabled_LeavesTypedPrefixUnchanged ),
    };

--- a/test/test_getline.c
+++ b/test/test_getline.c
@@ -339,6 +339,60 @@ static void getString_WhenRepeatedInvalidControlInputReceived_FlushesInput( void
    }
 }
 
+static void getName_WhenAutocompleteEnabled_ExpandsUniqueName( void **state )
+{
+   // Arrange
+   char *ptrResult;
+   const int aryKeys[] = { 'D', 'r', ' ', 'S', '\n' };
+
+   (void)state;
+
+   resetTracking();
+   teardownWhoList();
+   setupWhoList( "Dr Strange", "Meatball" );
+   flagsConfiguration.shouldEnableNameAutocomplete = 1;
+
+   setInputSequence( aryKeys, sizeof( aryKeys ) / sizeof( aryKeys[0] ) );
+
+   // Act
+   ptrResult = getName( 2 );
+
+   // Assert
+   if ( strcmp( ptrResult, "Dr Strange" ) != 0 )
+   {
+      fail_msg( "getName should expand unique prefixes when autocomplete is enabled; got '%s'", ptrResult );
+   }
+
+   teardownWhoList();
+}
+
+static void getName_WhenAutocompleteDisabled_LeavesTypedPrefixUnchanged( void **state )
+{
+   // Arrange
+   char *ptrResult;
+   const int aryKeys[] = { 'D', 'r', ' ', 'S', '\n' };
+
+   (void)state;
+
+   resetTracking();
+   teardownWhoList();
+   setupWhoList( "Dr Strange", "Meatball" );
+   flagsConfiguration.shouldEnableNameAutocomplete = 0;
+
+   setInputSequence( aryKeys, sizeof( aryKeys ) / sizeof( aryKeys[0] ) );
+
+   // Act
+   ptrResult = getName( 2 );
+
+   // Assert
+   if ( strcmp( ptrResult, "Dr S" ) != 0 )
+   {
+      fail_msg( "getName should keep typed text unchanged when autocomplete is disabled; got '%s'", ptrResult );
+   }
+
+   teardownWhoList();
+}
+
 int main( void )
 {
    const struct CMUnitTest aryTests[] = {
@@ -348,6 +402,8 @@ int main( void )
       cmocka_unit_test( getString_WhenCtrlWUsed_RemovesPreviousWord ),
       cmocka_unit_test( getString_WhenHiddenInputUsed_CapturesDotsInsteadOfPlainText ),
       cmocka_unit_test( getString_WhenRepeatedInvalidControlInputReceived_FlushesInput ),
+      cmocka_unit_test( getName_WhenAutocompleteEnabled_ExpandsUniqueName ),
+      cmocka_unit_test( getName_WhenAutocompleteDisabled_LeavesTypedPrefixUnchanged ),
    };
 
    return cmocka_run_group_tests( aryTests, NULL, NULL );

--- a/unix.c
+++ b/unix.c
@@ -370,7 +370,7 @@ void noTitleBar( void )
 
 /*
  * Open a socket connection to the bbs.  Defaults to BBS_HOSTNAME with port BBS_PORT_NUMBER
- * (by default a standard telnet to bbs.isca.uiowa.edu) but can be overridden
+ * (by default a standard telnet to bbs.iscabbs.com) but can be overridden
  * in the bbsrc file if/when the source to the ISCA BBS is released and others
  * start their own on different machines and/or ports.
  */
@@ -485,7 +485,7 @@ void connectBbs( void )
       isSsl = 1;
    }
 #endif
-   stdPrintf( "[%ssecure connection established]\n", ( shouldUseSsl ) ? "S" : "Ins" );
+   stdPrintf( "[%ssecure connection established]\n", ( shouldUseSsl ) ? "S" : "In" );
    titleBar();
    fflush( stdout );
 

--- a/unix.c
+++ b/unix.c
@@ -315,10 +315,10 @@ void openTmpFile( void )
 
 void titleBar( void )
 {
-#ifdef ENABLE_TITLEBAR
    char aryTitle[80];
 
-   if ( flagsConfiguration.isScreenReaderModeEnabled )
+   if ( !flagsConfiguration.shouldEnableTitleBar ||
+        flagsConfiguration.isScreenReaderModeEnabled )
    {
       return;
    }
@@ -337,14 +337,13 @@ void titleBar( void )
       printf( "\033]1;%s\\", aryTitle );
       printf( "\033]2;%s\\", aryTitle );
    }
-#endif
    return;
 }
 
 void noTitleBar( void )
 {
-#ifdef ENABLE_TITLEBAR
-   if ( flagsConfiguration.isScreenReaderModeEnabled )
+   if ( !flagsConfiguration.shouldEnableTitleBar ||
+        flagsConfiguration.isScreenReaderModeEnabled )
    {
       return;
    }
@@ -364,7 +363,6 @@ void noTitleBar( void )
       printf( "\033]2; (%s) %dx%d\033\\", rindex( (char *)ttyname( 0 ), '/' ) + 1, ws.ws_col, ws.ws_row );
    }
    fflush( stdout );
-#endif
    return;
 }
 

--- a/unix.c
+++ b/unix.c
@@ -318,6 +318,11 @@ void titleBar( void )
 #ifdef ENABLE_TITLEBAR
    char aryTitle[80];
 
+   if ( flagsConfiguration.isScreenReaderModeEnabled )
+   {
+      return;
+   }
+
    snprintf( aryTitle, sizeof( aryTitle ), "%s:%d%s - BBS Client %s (%s)",
              aryCommandLineHost, cmdLinePort, isSsl ? " (Secure)" : "",
              VERSION, "Unix" );
@@ -339,6 +344,11 @@ void titleBar( void )
 void noTitleBar( void )
 {
 #ifdef ENABLE_TITLEBAR
+   if ( flagsConfiguration.isScreenReaderModeEnabled )
+   {
+      return;
+   }
+
    /* xterm */
    if ( !strcmp( getenv( "TERM" ), "xterm" ) )
    {

--- a/unix.c
+++ b/unix.c
@@ -313,6 +313,34 @@ void openTmpFile( void )
    }
 }
 
+static bool terminalSupportsTitleBarUpdates( void )
+{
+   const char *ptrTerm;
+   const char *ptrTermProgram;
+
+   ptrTerm = getenv( "TERM" );
+   ptrTermProgram = getenv( "TERM_PROGRAM" );
+
+   if ( ptrTermProgram != NULL &&
+        ( strcmp( ptrTermProgram, "Apple_Terminal" ) == 0 ||
+          strcmp( ptrTermProgram, "iTerm.app" ) == 0 ) )
+   {
+      return true;
+   }
+   if ( ptrTerm == NULL )
+   {
+      return false;
+   }
+   if ( strncmp( ptrTerm, "xterm", 5 ) == 0 ||
+        strncmp( ptrTerm, "screen", 6 ) == 0 ||
+        strncmp( ptrTerm, "tmux", 4 ) == 0 )
+   {
+      return true;
+   }
+
+   return false;
+}
+
 void titleBar( void )
 {
    char aryTitle[80];
@@ -326,16 +354,10 @@ void titleBar( void )
    snprintf( aryTitle, sizeof( aryTitle ), "%s:%d%s - BBS Client %s (%s)",
              aryCommandLineHost, cmdLinePort, isSsl ? " (Secure)" : "",
              VERSION, "Unix" );
-   /* xterm */
-   if ( !strcmp( getenv( "TERM" ), "xterm" ) )
+   if ( terminalSupportsTitleBarUpdates() )
    {
       printf( "\033]0;%s\007", aryTitle );
-   }
-   /* NeXT */
-   if ( getenv( "STUART" ) )
-   {
-      printf( "\033]1;%s\\", aryTitle );
-      printf( "\033]2;%s\\", aryTitle );
+      fflush( stdout );
    }
    return;
 }
@@ -348,21 +370,11 @@ void noTitleBar( void )
       return;
    }
 
-   /* xterm */
-   if ( !strcmp( getenv( "TERM" ), "xterm" ) )
+   if ( terminalSupportsTitleBarUpdates() )
    {
-      printf( "\033]0;xterm\007" );
+      printf( "\033]0;\007" );
+      fflush( stdout );
    }
-   /* NeXT */
-   if ( getenv( "STUART" ) )
-   {
-      struct winsize ws;
-
-      ioctl( 0, TIOCGWINSZ, (char *)&ws );
-      printf( "\033]1; csh (%s)\033\\", rindex( (char *)ttyname( 0 ), '/' ) + 1 );
-      printf( "\033]2; (%s) %dx%d\033\\", rindex( (char *)ttyname( 0 ), '/' ) + 1, ws.ws_col, ws.ws_row );
-   }
-   fflush( stdout );
    return;
 }
 

--- a/utility.c
+++ b/utility.c
@@ -317,16 +317,22 @@ void tempFileError( void )
 
 int more( int *line, int percentComplete )
 {
+   char aryPrompt[96];
    unsigned int invalid = 0;
 
    if ( percentComplete >= 0 )
    {
-      printf( "--MORE--(%d%%)", percentComplete );
+      snprintf( aryPrompt, sizeof( aryPrompt ),
+                "Page break (%d%%): Space next page, Enter next line, Q quit",
+                percentComplete );
    }
    else
    {
-      printf( "--MORE--" );
+      snprintf( aryPrompt, sizeof( aryPrompt ),
+                "%s",
+                "Page break: Space next page, Enter next line, Q quit" );
    }
+   printf( "%s", aryPrompt );
    while ( true )
    {
       register int inputChar;
@@ -349,7 +355,7 @@ int more( int *line, int percentComplete )
          handleInvalidInput( &invalid );
          continue;
       }
-      printf( "\r              \r" );
+      printf( "\r%*s\r", (int)strlen( aryPrompt ), "" );
       break;
    }
    return ( *line < 0 ? -1 : 0 );

--- a/utility.c
+++ b/utility.c
@@ -257,6 +257,53 @@ int readValidatedMenuKey( const char *allowedCharsLowercase )
    }
 }
 
+void printAnsiForegroundColorValue( int colorValue )
+{
+   char aryAnsiSequence[32];
+
+   if ( !flagsConfiguration.useAnsi )
+   {
+      return;
+   }
+
+   formatAnsiForegroundSequence( aryAnsiSequence, sizeof( aryAnsiSequence ),
+                                 colorValue );
+   stdPrintf( "%s", aryAnsiSequence );
+}
+
+void printThemedMnemonicText( const char *ptrText, int defaultColor )
+{
+   const char *ptrScan;
+
+   if ( ptrText == NULL )
+   {
+      return;
+   }
+
+   if ( !flagsConfiguration.useAnsi )
+   {
+      stdPrintf( "%s", ptrText );
+      return;
+   }
+
+   printAnsiForegroundColorValue( defaultColor );
+
+   for ( ptrScan = ptrText; *ptrScan; )
+   {
+      if ( ptrScan[0] == '<' && ptrScan[1] != '\0' && ptrScan[2] == '>' )
+      {
+         printAnsiForegroundColorValue( color.forum );
+         stdPutChar( ptrScan[1] );
+         printAnsiForegroundColorValue( defaultColor );
+         ptrScan += 3;
+         continue;
+      }
+
+      stdPutChar( *ptrScan );
+      ptrScan++;
+   }
+}
+
 int yesNo( void )
 {
    register int inputChar;


### PR DESCRIPTION
- bug fixes (introduced in other changes)
- Add screenreader mode:
  - Prompts you at startup
  - Changes default settings to be more friendly
- Replace --MORE-- prompts where possible; not sure if I like this
- Username autocomplete can now be toggled on/off
- Remove support for hidden CTRL+R -- redraw line -- feature
- Add Brilliant color scheme
- Support for terminal title changes is now configurable, and modernized for OSC
- Other tweaks and improvements